### PR TITLE
Ignore CA bundles of webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ignore CA bundles of webhooks ([#2])
 
+### Fixed
+
+- Remove empty `finalizers` field on root app ([#2])
+
 [Unreleased]: https://github.com/projectsyn/component-argocd/compare/546caccdd6868a8085aaa29d9e7a159ea53ff0aa..HEAD
 [#1]: https://github.com/projectsyn/component-argocd/pull/1
 [#2]: https://github.com/projectsyn/component-argocd/pull/2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Open source component ([#1])
-- Update Argo CD to v1.6.1 ([#3])
+- Update Argo CD to v1.6.1
+
+### Added
+
+- Ignore CA bundles of webhooks ([#2])
 
 [Unreleased]: https://github.com/projectsyn/component-argocd/compare/546caccdd6868a8085aaa29d9e7a159ea53ff0aa..HEAD
 [#1]: https://github.com/projectsyn/component-argocd/pull/1
-[#3]: https://github.com/projectsyn/component-argocd/pull/3
+[#2]: https://github.com/projectsyn/component-argocd/pull/2

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -19,8 +19,9 @@ local default_project = argocd.Project('default') {
   },
 };
 local root_app = argocd.App('root', params.namespace, secrets=false) {
-  metadata+: {
-    finalizers: [],
+  metadata: {
+    name: 'root',
+    namespace: params.namespace,
   },
   spec+: {
     source+: {

--- a/component/config.jsonnet
+++ b/component/config.jsonnet
@@ -28,6 +28,14 @@ local config = [
             key: sshPrivateKey
       |||,
       'resource.customizations': |||
+        admissionregistration.k8s.io/MutatingWebhookConfiguration:
+          ignoreDifferences: |
+            jsonPointers:
+              - /webhooks/0/clientConfig/caBundle
+        admissionregistration.k8s.io/ValidatingWebhookConfiguration:
+          ignoreDifferences: |
+            jsonPointers:
+              - /webhooks/0/clientConfig/caBundle
         apiextensions.k8s.io/CustomResourceDefinition:
           ignoreDifferences: |
             jsonPointers:

--- a/lib/argocd.libjsonnet
+++ b/lib/argocd.libjsonnet
@@ -4,9 +4,7 @@
  */
 
 
-local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
-local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.argocd;
 


### PR DESCRIPTION
Since they usually are injected on the cluster and Argo CD can safely
ignore them.

<!--
Thank you for your pull request. Please provide a description above and review
the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] keep pull requests small so they can be easily reviewed
- [x] update ./CHANGELOG.md


<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
