### PR TITLE
Upgrade ArgoCD to `v2.0.4`. Bitnami Redis image as default.

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,21 +6,21 @@ parameters:
       dashboards: false
       prometheus_rule_labels:
         prometheus: platform
-    git_tag: v1.8.7
+    git_tag: v2.0.4
     resync_seconds: 180
     images:
       argocd:
-        image: docker.io/argoproj/argocd
-        tag: 'v1.8.7@sha256:ce34acd7bac34d5a4fdbf96faf11fa5e01a7f96a27041d4472ca498886000cbf'
+        image: quay.io/argoproj/argocd
+        tag: 'v2.0.4@sha256:976dfbfadb817ba59f4f641597a13df7b967cd5a1059c966fa843869c9463348'
       redis:
         image: docker.io/redis
-        tag: '5.0.9@sha256:ab3998e18bfaa570fad08c884ffbcc7861f59caf736a5a0c1ad5383c4d863958'
+        tag: '6.2.4@sha256:f631ff6c898339306ffdb8369add5c12303ec3946610ef8d6f1d05f575942f0c'
       kapitan:
         image: docker.io/projectsyn/kapitan
-        tag: 'v0.29.1@sha256:14f31adadb5d1a28fa097a98bb48bb5a2a0cc1fbaa6f3bcd915e8ba7cd016662'
+        tag: 'v0.29.5@sha256:f0ddfc1052a2dc11c4c4ce97d0a784995b7b0fd8e1f8e032edb7606431b2733a'
       vault_agent:
         image: docker.io/vault
-        tag: '1.5.3@sha256:14c29a6810974d3611c578509ad9398cadf44e8f6fa354c7d1ced62b5f26d372'
+        tag: '1.5.8@sha256:3b2209bedb1bbc70315fcd9e2187a49a1359f8f6f46cca7a51efcadb461fe98a'
     ssh_known_hosts: |
       git.vshn.net ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCnE1dMkh+3uHWck+cTvQqeNUW0lj1uVcIC9JX2Tg6gmkKCYA73+o+I7vo4g6nPtSOAfITvYdHJLzwE9GwlSFsXHMR9q0ErWl2wC+w6FawLMz9//5XqiBi2qq/8WnWp3ecY16jDoGRW4eymT+USFHKJVi696XBy3WE/0BBapPZ58WPqkKN6A27qkIK6FehI80f+zN4ZqikdwWuCFs35fsimcmLnWqWPm8zbOkgCiB+ov4O/xmRNHwJWCk/qzU6X/M9YtMXzAa5mjwDvcHSAizFD3a3Fv68G1VsmRZ0THLrRKM/WOxrWNZoimSNgyjTzoCwiKeckvL5+hpNcNSW+eBPt
       git.vshn.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO9EkPcVdsz/oVTI2VJkBlq8Mv/dg3rhcbgzAEKyiwUG

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -13,8 +13,8 @@ parameters:
         image: quay.io/argoproj/argocd
         tag: 'v2.0.4@sha256:976dfbfadb817ba59f4f641597a13df7b967cd5a1059c966fa843869c9463348'
       redis:
-        image: docker.io/redis
-        tag: '6.2.4@sha256:f631ff6c898339306ffdb8369add5c12303ec3946610ef8d6f1d05f575942f0c'
+        image: quay.io/bitnami/redis
+        tag: '6.2.4'
       kapitan:
         image: docker.io/projectsyn/kapitan
         tag: 'v0.29.5@sha256:f0ddfc1052a2dc11c4c4ce97d0a784995b7b0fd8e1f8e032edb7606431b2733a'

--- a/component/redis.jsonnet
+++ b/component/redis.jsonnet
@@ -14,18 +14,23 @@ local objects = [
     spec+: {
       template+: {
         spec+: {
-          [if std.startsWith(inv.parameters.facts.distribution, 'openshift') then
-            'securityContext']:: {},
+          securityContext:: {},
           volumes: [ {
             name: 'data',
             emptyDir: {},
           } ],
           containers: [ deployment.spec.template.spec.containers[0] {
             image: image,
+            args: [],
+            env+: [
+              { name: 'ALLOW_EMPTY_PASSWORD', value: 'yes' },
+              { name: 'REDIS_AOF_ENABLED', value: 'no' },
+              { name: 'REDIS_EXTRA_FLAGS', value: "--save ''" },
+            ],
             imagePullPolicy: 'IfNotPresent',
             volumeMounts: [ {
               name: 'data',
-              mountPath: '/data',
+              mountPath: '/bitnami/redis/data',
             } ],
           } ],
         },

--- a/component/redis.jsonnet
+++ b/component/redis.jsonnet
@@ -9,6 +9,35 @@ local role = std.parseJson(kap.yaml_load('argocd/manifests/' + params.git_tag + 
 local role_binding = std.parseJson(kap.yaml_load('argocd/manifests/' + params.git_tag + '/redis/argocd-redis-rolebinding.yaml'));
 local serviceaccount = std.parseJson(kap.yaml_load('argocd/manifests/' + params.git_tag + '/redis/argocd-redis-sa.yaml'));
 local service = std.parseJson(kap.yaml_load('argocd/manifests/' + params.git_tag + '/redis/argocd-redis-service.yaml'));
+
+
+local redisSpec(image) =
+  local strContains(s, substr) = std.findSubstr(substr, s) != [];
+
+  local volumeMounts(path) = [ {
+    name: 'data',
+    mountPath: path,
+  } ];
+
+  {
+    image: image,
+    imagePullPolicy: 'IfNotPresent',
+  } +
+  if strContains(image, 'bitnami') then
+    {
+      env+: [
+        { name: 'ALLOW_EMPTY_PASSWORD', value: 'yes' },
+        { name: 'REDIS_AOF_ENABLED', value: 'no' },
+        { name: 'REDIS_EXTRA_FLAGS', value: "--save ''" },
+      ],
+      args: [],
+      volumeMounts: volumeMounts('/bitnami/redis/data'),
+    }
+  else
+    {
+      volumeMounts: volumeMounts('/data'),
+    };
+
 local objects = [
   deployment {
     spec+: {
@@ -19,20 +48,9 @@ local objects = [
             name: 'data',
             emptyDir: {},
           } ],
-          containers: [ deployment.spec.template.spec.containers[0] {
-            image: image,
-            args: [],
-            env+: [
-              { name: 'ALLOW_EMPTY_PASSWORD', value: 'yes' },
-              { name: 'REDIS_AOF_ENABLED', value: 'no' },
-              { name: 'REDIS_EXTRA_FLAGS', value: "--save ''" },
-            ],
-            imagePullPolicy: 'IfNotPresent',
-            volumeMounts: [ {
-              name: 'data',
-              mountPath: '/bitnami/redis/data',
-            } ],
-          } ],
+          containers: [
+            deployment.spec.template.spec.containers[0] + redisSpec(image),
+          ],
         },
       },
     },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -42,6 +42,8 @@ type:: dictionary
 
 Dictionary containing the container images used by this component.
 
+NOTE: For Redis, both https://hub.docker.com/_/redis[`library/redis`] and https://hub.docker.com/r/bitnami/redis[`bitnami/redis`] images are supported.
+
 == `monitoring.enabled`
 
 [horizontal]


### PR DESCRIPTION
This PR updates ArgoCD from `v1.8.7` to `v2.0.4`. 

This PR also switches the default Redis image to `bitnami/redis`. The official image is still supported.

Fixes #18.