### PR TITLE
Add cluster_id and tenant_id labels to alert rules

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,6 +6,8 @@ parameters:
       dashboards: false
       prometheus_rule_labels:
         prometheus: platform
+        cluster_id: ${cluster:name}
+        tenant_id: ${cluster:tenant}
     git_tag: v2.0.4
     resync_seconds: 180
     images:

--- a/tests/golden/defaults/argocd/argocd/10_config/20_monitoring.yaml
+++ b/tests/golden/defaults/argocd/argocd/10_config/20_monitoring.yaml
@@ -57,9 +57,11 @@ kind: PrometheusRule
 metadata:
   annotations: {}
   labels:
+    cluster_id: c-green-test-1234
     name: argocd
     prometheus: platform
     role: alert-rules
+    tenant_id: t-silent-test-1234
   name: argocd
   namespace: syn
 spec:


### PR DESCRIPTION
Add cluster_id and tenant_id labels to the alert rules. This allows to group alerts in Opsgenie by cluster. Otherwise alerts from ArgoCD use the same alias for all clusters and are bundled together into a single alert. 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
