### PR TITLE
Make distribution configurable instead of directly reading facts

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,6 +1,7 @@
 parameters:
   argocd:
     namespace: syn
+    distribution: ${facts:distribution}
     monitoring:
       enabled: true
       dashboards: false

--- a/component/redis.jsonnet
+++ b/component/redis.jsonnet
@@ -9,7 +9,7 @@ local role_binding = std.parseJson(kap.yaml_load('argocd/manifests/' + params.gi
 local serviceaccount = std.parseJson(kap.yaml_load('argocd/manifests/' + params.git_tag + '/redis/argocd-redis-sa.yaml'));
 local service = std.parseJson(kap.yaml_load('argocd/manifests/' + params.git_tag + '/redis/argocd-redis-service.yaml'));
 
-local isOnOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+local isOnOpenshift = std.startsWith(params.distribution, 'openshift');
 
 local redisContainerSpec(image) =
   {

--- a/component/repo-server.jsonnet
+++ b/component/repo-server.jsonnet
@@ -5,7 +5,7 @@ local inv = kap.inventory();
 local params = inv.parameters.argocd;
 local image = params.images.argocd.image + ':' + params.images.argocd.tag;
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+local isOpenshift = std.startsWith(params.distribution, 'openshift');
 local deployment = std.parseJson(kap.yaml_load('argocd/manifests/' + params.git_tag + '/repo-server/argocd-repo-server-deployment.yaml'));
 local service = std.parseJson(kap.yaml_load('argocd/manifests/' + params.git_tag + '/repo-server/argocd-repo-server-service.yaml'));
 local vault_agent_config = kube.ConfigMap('vault-agent-config') {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -11,6 +11,14 @@ default:: `syn`
 
 The namespace in which to deploy this component.
 
+== `distribution`
+
+[horizontal]
+type:: string
+default:: ${facts:distribution}
+
+The Kubernetes distribution of the cluster.
+
 == `git_tag`
 
 [horizontal]


### PR DESCRIPTION
This should be a noop for basically anyone, but allows us to change the behavior in very niche situation. I need this for example for a vCluster running on Openshift. Without it the host cluster will complain about the configured security context.



## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
