### PR TITLE
Make Vault integration more configurable

### DIFF
--- a/component/repo-server.jsonnet
+++ b/component/repo-server.jsonnet
@@ -12,7 +12,7 @@ local vault_agent_config = kube.ConfigMap('vault-agent-config') {
   data: {
     'vault-agent-config.json': std.manifestJson({
       exit_after_auth: false,
-      [if std.objectHas(inv.parameters.secret_management, 'vault_mount_path') then 'mount_path']: inv.parameters.secret_management.vault_mount_path,
+      [if std.objectHas(inv.parameters.secret_management, 'vault_auth_mount_path') then 'mount_path']: inv.parameters.secret_management.vault_auth_mount_path,
       auto_auth: {
         method: [
           {

--- a/component/repo-server.jsonnet
+++ b/component/repo-server.jsonnet
@@ -10,24 +10,32 @@ local deployment = std.parseJson(kap.yaml_load('argocd/manifests/' + params.git_
 local service = std.parseJson(kap.yaml_load('argocd/manifests/' + params.git_tag + '/repo-server/argocd-repo-server-service.yaml'));
 local vault_agent_config = kube.ConfigMap('vault-agent-config') {
   data: {
-    'vault-agent-config.hcl': |||
-      exit_after_auth = false
-
-      auto_auth {
-          method "kubernetes" {
-              config = {
-                  role = "%s"
-                  token_path = "/var/run/secrets/syn/token"
-              }
-          }
-          sink "file" {
-              config = {
-                  path = "/home/vault/.vault-token"
-                  mode = 0644
-              }
-          }
-      }
-    ||| % inv.parameters.secret_management.vault_role,
+    'vault-agent-config.json': std.manifestJson({
+      exit_after_auth: false,
+      [if std.objectHas(inv.parameters.secret_management, 'vault_mount_path') then 'mount_path']: inv.parameters.secret_management.vault_mount_path,
+      auto_auth: {
+        method: [
+          {
+            type: 'kubernetes',
+            config: {
+              role: inv.parameters.secret_management.vault_role,
+              token_path: '/var/run/secrets/syn/token',
+            },
+          },
+        ],
+        sinks: [
+          {
+            sink: {
+              type: 'file',
+              config: {
+                path: '/home/vault/.vault-token',
+                mode: 644,
+              },
+            },
+          },
+        ],
+      },
+    }),
   },
 };
 local objects = [
@@ -86,7 +94,7 @@ local objects = [
             args: [
               'agent',
               '-config',
-              '/etc/vault/vault-agent-config.hcl',
+              '/etc/vault/vault-agent-config.json',
             ],
             [if !isOpenshift then 'securityContext']: {
               runAsUser: 100,

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,5 +1,5 @@
 parameters:
   secret_management:
     vault_role: test
-    vault_mount_path: lieutenant
+    vault_auth_mount_path: auth/lieutenant
     vault_addr: test.syn.tools

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,4 +1,5 @@
 parameters:
   secret_management:
     vault_role: test
+    vault_mount_path: lieutenant
     vault_addr: test.syn.tools

--- a/tests/golden/defaults/argocd/argocd/30_repo-server/configmap.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_repo-server/configmap.yaml
@@ -9,7 +9,7 @@ data:
     \                    \"path\": \"/home/vault/.vault-token\"\n                \
     \    },\n                    \"type\": \"file\"\n                }\n         \
     \   }\n        ]\n    },\n    \"exit_after_auth\": false,\n    \"mount_path\"\
-    : \"lieutenant\"\n}"
+    : \"auth/lieutenant\"\n}"
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/defaults/argocd/argocd/30_repo-server/configmap.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_repo-server/configmap.yaml
@@ -1,10 +1,15 @@
 apiVersion: v1
 data:
-  vault-agent-config.hcl: "exit_after_auth = false\n\nauto_auth {\n    method \"kubernetes\"\
-    \ {\n        config = {\n            role = \"test\"\n            token_path =\
-    \ \"/var/run/secrets/syn/token\"\n        }\n    }\n    sink \"file\" {\n    \
-    \    config = {\n            path = \"/home/vault/.vault-token\"\n           \
-    \ mode = 0644\n        }\n    }\n}\n"
+  vault-agent-config.json: "{\n    \"auto_auth\": {\n        \"method\": [\n     \
+    \       {\n                \"config\": {\n                    \"role\": \"test\"\
+    ,\n                    \"token_path\": \"/var/run/secrets/syn/token\"\n      \
+    \          },\n                \"type\": \"kubernetes\"\n            }\n     \
+    \   ],\n        \"sinks\": [\n            {\n                \"sink\": {\n   \
+    \                 \"config\": {\n                        \"mode\": 644,\n    \
+    \                    \"path\": \"/home/vault/.vault-token\"\n                \
+    \    },\n                    \"type\": \"file\"\n                }\n         \
+    \   }\n        ]\n    },\n    \"exit_after_auth\": false,\n    \"mount_path\"\
+    : \"lieutenant\"\n}"
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/defaults/argocd/argocd/30_repo-server/deployment.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_repo-server/deployment.yaml
@@ -176,7 +176,7 @@ spec:
         - args:
             - agent
             - -config
-            - /etc/vault/vault-agent-config.hcl
+            - /etc/vault/vault-agent-config.json
           env:
             - name: SKIP_SETCAP
               value: 'true'

--- a/tests/golden/openshift/argocd/argocd/30_repo-server/configmap.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_repo-server/configmap.yaml
@@ -1,10 +1,14 @@
 apiVersion: v1
 data:
-  vault-agent-config.hcl: "exit_after_auth = false\n\nauto_auth {\n    method \"kubernetes\"\
-    \ {\n        config = {\n            role = \"test\"\n            token_path =\
-    \ \"/var/run/secrets/syn/token\"\n        }\n    }\n    sink \"file\" {\n    \
-    \    config = {\n            path = \"/home/vault/.vault-token\"\n           \
-    \ mode = 0644\n        }\n    }\n}\n"
+  vault-agent-config.json: "{\n    \"auto_auth\": {\n        \"method\": [\n     \
+    \       {\n                \"config\": {\n                    \"role\": \"test\"\
+    ,\n                    \"token_path\": \"/var/run/secrets/syn/token\"\n      \
+    \          },\n                \"type\": \"kubernetes\"\n            }\n     \
+    \   ],\n        \"sinks\": [\n            {\n                \"sink\": {\n   \
+    \                 \"config\": {\n                        \"mode\": 644,\n    \
+    \                    \"path\": \"/home/vault/.vault-token\"\n                \
+    \    },\n                    \"type\": \"file\"\n                }\n         \
+    \   }\n        ]\n    },\n    \"exit_after_auth\": false\n}"
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/openshift/argocd/argocd/30_repo-server/deployment.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_repo-server/deployment.yaml
@@ -176,7 +176,7 @@ spec:
         - args:
             - agent
             - -config
-            - /etc/vault/vault-agent-config.hcl
+            - /etc/vault/vault-agent-config.json
           env:
             - name: SKIP_SETCAP
               value: 'true'

--- a/tests/golden/params/argocd/argocd/30_repo-server/configmap.yaml
+++ b/tests/golden/params/argocd/argocd/30_repo-server/configmap.yaml
@@ -1,10 +1,14 @@
 apiVersion: v1
 data:
-  vault-agent-config.hcl: "exit_after_auth = false\n\nauto_auth {\n    method \"kubernetes\"\
-    \ {\n        config = {\n            role = \"test\"\n            token_path =\
-    \ \"/var/run/secrets/syn/token\"\n        }\n    }\n    sink \"file\" {\n    \
-    \    config = {\n            path = \"/home/vault/.vault-token\"\n           \
-    \ mode = 0644\n        }\n    }\n}\n"
+  vault-agent-config.json: "{\n    \"auto_auth\": {\n        \"method\": [\n     \
+    \       {\n                \"config\": {\n                    \"role\": \"test\"\
+    ,\n                    \"token_path\": \"/var/run/secrets/syn/token\"\n      \
+    \          },\n                \"type\": \"kubernetes\"\n            }\n     \
+    \   ],\n        \"sinks\": [\n            {\n                \"sink\": {\n   \
+    \                 \"config\": {\n                        \"mode\": 644,\n    \
+    \                    \"path\": \"/home/vault/.vault-token\"\n                \
+    \    },\n                    \"type\": \"file\"\n                }\n         \
+    \   }\n        ]\n    },\n    \"exit_after_auth\": false\n}"
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/params/argocd/argocd/30_repo-server/deployment.yaml
+++ b/tests/golden/params/argocd/argocd/30_repo-server/deployment.yaml
@@ -170,7 +170,7 @@ spec:
         - args:
             - agent
             - -config
-            - /etc/vault/vault-agent-config.hcl
+            - /etc/vault/vault-agent-config.json
           env:
             - name: SKIP_SETCAP
               value: 'true'


### PR DESCRIPTION
To be able to migrate vault we need the option to configure a mount path.

We switch to JSON config as it's easier to template. This will generate a diff on every cluster, but it's the exact same configuration, just in JSON instead of HCL.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
