### PR TITLE
Add custom health check for OLM subscriptions

### DIFF
--- a/component/config.jsonnet
+++ b/component/config.jsonnet
@@ -74,6 +74,7 @@ local config = [
           health.lua.useOpenLibs: true
           health.lua: |
             -- Base check copied from upstream
+            -- See https://github.com/argoproj/argo-cd/blob/f3730da01ef05c0b7ae97385aca6642faf9e4c52/resource_customizations/operators.coreos.com/Subscription/health.lua
             health_status = {}
             if obj.status ~= nil then
               if obj.status.conditions ~= nil then
@@ -85,6 +86,8 @@ local config = [
                   if condition.type == "InstallPlanPending" and condition.status == "True" then
                     numPending = numPending + 1
                   elseif (condition.type == "CatalogSourcesUnhealthy" or condition.type == "InstallPlanMissing" or condition.type == "InstallPlanFailed" or condition.type == "ResolutionFailed") and condition.status == "True" then
+                    -- Custom check to ignore ConstraintsNotSatisfiable for
+                    -- cilium-enterprise subscription.
                     if condition.type == "ResolutionFailed"  and condition.reason == "ConstraintsNotSatisfiable" and string.find(condition.message, "cilium%-enterprise") then
                       msg = msg .. "; Ignoring ConstraintsNotSatisfiable for cilium-enterprise subscription"
                     else

--- a/tests/golden/defaults/argocd/argocd/10_config/10_argocd-cm.yaml
+++ b/tests/golden/defaults/argocd/argocd/10_config/10_argocd-cm.yaml
@@ -24,7 +24,8 @@ data:
     \ hs\n      end\n    end\n\n    hs.status = \"Progressing\"\n    hs.message =\
     \ \"Waiting for provider to be installed\"\n    return hs\noperators.coreos.com/Subscription:\n\
     \  health.lua.useOpenLibs: true\n  health.lua: |\n    -- Base check copied from\
-    \ upstream\n    health_status = {}\n    if obj.status ~= nil then\n      if obj.status.conditions\
+    \ upstream\n    -- See https://github.com/argoproj/argo-cd/blob/f3730da01ef05c0b7ae97385aca6642faf9e4c52/resource_customizations/operators.coreos.com/Subscription/health.lua\n\
+    \    health_status = {}\n    if obj.status ~= nil then\n      if obj.status.conditions\
     \ ~= nil then\n        numDegraded = 0\n        numPending = 0\n        msg =\
     \ \"\"\n        for i, condition in pairs(obj.status.conditions) do\n        \
     \  msg = msg .. i .. \": \" .. condition.type .. \" | \" .. condition.status ..\
@@ -32,10 +33,12 @@ data:
     \ == \"True\" then\n            numPending = numPending + 1\n          elseif\
     \ (condition.type == \"CatalogSourcesUnhealthy\" or condition.type == \"InstallPlanMissing\"\
     \ or condition.type == \"InstallPlanFailed\" or condition.type == \"ResolutionFailed\"\
-    ) and condition.status == \"True\" then\n            if condition.type == \"ResolutionFailed\"\
-    \  and condition.reason == \"ConstraintsNotSatisfiable\" and string.find(condition.message,\
-    \ \"cilium%-enterprise\") then\n              msg = msg .. \"; Ignoring ConstraintsNotSatisfiable\
-    \ for cilium-enterprise subscription\"\n            else\n              numDegraded\
+    ) and condition.status == \"True\" then\n            -- Custom check to ignore\
+    \ ConstraintsNotSatisfiable for\n            -- cilium-enterprise subscription.\n\
+    \            if condition.type == \"ResolutionFailed\"  and condition.reason ==\
+    \ \"ConstraintsNotSatisfiable\" and string.find(condition.message, \"cilium%-enterprise\"\
+    ) then\n              msg = msg .. \"; Ignoring ConstraintsNotSatisfiable for\
+    \ cilium-enterprise subscription\"\n            else\n              numDegraded\
     \ = numDegraded + 1\n            end\n          end\n        end\n        if numDegraded\
     \ == 0 and numPending == 0 then\n          health_status.status = \"Healthy\"\n\
     \          health_status.message = msg\n          return health_status\n     \

--- a/tests/golden/defaults/argocd/argocd/10_config/10_argocd-cm.yaml
+++ b/tests/golden/defaults/argocd/argocd/10_config/10_argocd-cm.yaml
@@ -22,7 +22,30 @@ data:
     Healthy\"\n        else\n          hs.status = \"Degraded\"\n        end\n   \
     \     hs.message = installed_message .. \" \" .. healthy_message\n        return\
     \ hs\n      end\n    end\n\n    hs.status = \"Progressing\"\n    hs.message =\
-    \ \"Waiting for provider to be installed\"\n    return hs\n"
+    \ \"Waiting for provider to be installed\"\n    return hs\noperators.coreos.com/Subscription:\n\
+    \  health.lua.useOpenLibs: true\n  health.lua: |\n    -- Base check copied from\
+    \ upstream\n    health_status = {}\n    if obj.status ~= nil then\n      if obj.status.conditions\
+    \ ~= nil then\n        numDegraded = 0\n        numPending = 0\n        msg =\
+    \ \"\"\n        for i, condition in pairs(obj.status.conditions) do\n        \
+    \  msg = msg .. i .. \": \" .. condition.type .. \" | \" .. condition.status ..\
+    \ \"\\n\"\n          if condition.type == \"InstallPlanPending\" and condition.status\
+    \ == \"True\" then\n            numPending = numPending + 1\n          elseif\
+    \ (condition.type == \"CatalogSourcesUnhealthy\" or condition.type == \"InstallPlanMissing\"\
+    \ or condition.type == \"InstallPlanFailed\" or condition.type == \"ResolutionFailed\"\
+    ) and condition.status == \"True\" then\n            if condition.type == \"ResolutionFailed\"\
+    \  and condition.reason == \"ConstraintsNotSatisfiable\" and string.find(condition.message,\
+    \ \"cilium%-enterprise\") then\n              msg = msg .. \"; Ignoring ConstraintsNotSatisfiable\
+    \ for cilium-enterprise subscription\"\n            else\n              numDegraded\
+    \ = numDegraded + 1\n            end\n          end\n        end\n        if numDegraded\
+    \ == 0 and numPending == 0 then\n          health_status.status = \"Healthy\"\n\
+    \          health_status.message = msg\n          return health_status\n     \
+    \   elseif numPending > 0 and numDegraded == 0 then\n          health_status.status\
+    \ = \"Progressing\"\n          health_status.message = \"An install plan for a\
+    \ subscription is pending installation\"\n          return health_status\n   \
+    \     else\n          health_status.status = \"Degraded\"\n          health_status.message\
+    \ = msg\n          return health_status\n        end\n      end\n    end\n   \
+    \ health_status.status = \"Progressing\"\n    health_status.message = \"An install\
+    \ plan for a subscription is pending installation\"\n    return health_status\n"
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/openshift/argocd/argocd/10_config/10_argocd-cm.yaml
+++ b/tests/golden/openshift/argocd/argocd/10_config/10_argocd-cm.yaml
@@ -24,7 +24,8 @@ data:
     \ hs\n      end\n    end\n\n    hs.status = \"Progressing\"\n    hs.message =\
     \ \"Waiting for provider to be installed\"\n    return hs\noperators.coreos.com/Subscription:\n\
     \  health.lua.useOpenLibs: true\n  health.lua: |\n    -- Base check copied from\
-    \ upstream\n    health_status = {}\n    if obj.status ~= nil then\n      if obj.status.conditions\
+    \ upstream\n    -- See https://github.com/argoproj/argo-cd/blob/f3730da01ef05c0b7ae97385aca6642faf9e4c52/resource_customizations/operators.coreos.com/Subscription/health.lua\n\
+    \    health_status = {}\n    if obj.status ~= nil then\n      if obj.status.conditions\
     \ ~= nil then\n        numDegraded = 0\n        numPending = 0\n        msg =\
     \ \"\"\n        for i, condition in pairs(obj.status.conditions) do\n        \
     \  msg = msg .. i .. \": \" .. condition.type .. \" | \" .. condition.status ..\
@@ -32,10 +33,12 @@ data:
     \ == \"True\" then\n            numPending = numPending + 1\n          elseif\
     \ (condition.type == \"CatalogSourcesUnhealthy\" or condition.type == \"InstallPlanMissing\"\
     \ or condition.type == \"InstallPlanFailed\" or condition.type == \"ResolutionFailed\"\
-    ) and condition.status == \"True\" then\n            if condition.type == \"ResolutionFailed\"\
-    \  and condition.reason == \"ConstraintsNotSatisfiable\" and string.find(condition.message,\
-    \ \"cilium%-enterprise\") then\n              msg = msg .. \"; Ignoring ConstraintsNotSatisfiable\
-    \ for cilium-enterprise subscription\"\n            else\n              numDegraded\
+    ) and condition.status == \"True\" then\n            -- Custom check to ignore\
+    \ ConstraintsNotSatisfiable for\n            -- cilium-enterprise subscription.\n\
+    \            if condition.type == \"ResolutionFailed\"  and condition.reason ==\
+    \ \"ConstraintsNotSatisfiable\" and string.find(condition.message, \"cilium%-enterprise\"\
+    ) then\n              msg = msg .. \"; Ignoring ConstraintsNotSatisfiable for\
+    \ cilium-enterprise subscription\"\n            else\n              numDegraded\
     \ = numDegraded + 1\n            end\n          end\n        end\n        if numDegraded\
     \ == 0 and numPending == 0 then\n          health_status.status = \"Healthy\"\n\
     \          health_status.message = msg\n          return health_status\n     \

--- a/tests/golden/openshift/argocd/argocd/10_config/10_argocd-cm.yaml
+++ b/tests/golden/openshift/argocd/argocd/10_config/10_argocd-cm.yaml
@@ -22,7 +22,30 @@ data:
     Healthy\"\n        else\n          hs.status = \"Degraded\"\n        end\n   \
     \     hs.message = installed_message .. \" \" .. healthy_message\n        return\
     \ hs\n      end\n    end\n\n    hs.status = \"Progressing\"\n    hs.message =\
-    \ \"Waiting for provider to be installed\"\n    return hs\n"
+    \ \"Waiting for provider to be installed\"\n    return hs\noperators.coreos.com/Subscription:\n\
+    \  health.lua.useOpenLibs: true\n  health.lua: |\n    -- Base check copied from\
+    \ upstream\n    health_status = {}\n    if obj.status ~= nil then\n      if obj.status.conditions\
+    \ ~= nil then\n        numDegraded = 0\n        numPending = 0\n        msg =\
+    \ \"\"\n        for i, condition in pairs(obj.status.conditions) do\n        \
+    \  msg = msg .. i .. \": \" .. condition.type .. \" | \" .. condition.status ..\
+    \ \"\\n\"\n          if condition.type == \"InstallPlanPending\" and condition.status\
+    \ == \"True\" then\n            numPending = numPending + 1\n          elseif\
+    \ (condition.type == \"CatalogSourcesUnhealthy\" or condition.type == \"InstallPlanMissing\"\
+    \ or condition.type == \"InstallPlanFailed\" or condition.type == \"ResolutionFailed\"\
+    ) and condition.status == \"True\" then\n            if condition.type == \"ResolutionFailed\"\
+    \  and condition.reason == \"ConstraintsNotSatisfiable\" and string.find(condition.message,\
+    \ \"cilium%-enterprise\") then\n              msg = msg .. \"; Ignoring ConstraintsNotSatisfiable\
+    \ for cilium-enterprise subscription\"\n            else\n              numDegraded\
+    \ = numDegraded + 1\n            end\n          end\n        end\n        if numDegraded\
+    \ == 0 and numPending == 0 then\n          health_status.status = \"Healthy\"\n\
+    \          health_status.message = msg\n          return health_status\n     \
+    \   elseif numPending > 0 and numDegraded == 0 then\n          health_status.status\
+    \ = \"Progressing\"\n          health_status.message = \"An install plan for a\
+    \ subscription is pending installation\"\n          return health_status\n   \
+    \     else\n          health_status.status = \"Degraded\"\n          health_status.message\
+    \ = msg\n          return health_status\n        end\n      end\n    end\n   \
+    \ health_status.status = \"Progressing\"\n    health_status.message = \"An install\
+    \ plan for a subscription is pending installation\"\n    return health_status\n"
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/params/argocd/argocd/10_config/10_argocd-cm.yaml
+++ b/tests/golden/params/argocd/argocd/10_config/10_argocd-cm.yaml
@@ -24,7 +24,8 @@ data:
     \ hs\n      end\n    end\n\n    hs.status = \"Progressing\"\n    hs.message =\
     \ \"Waiting for provider to be installed\"\n    return hs\noperators.coreos.com/Subscription:\n\
     \  health.lua.useOpenLibs: true\n  health.lua: |\n    -- Base check copied from\
-    \ upstream\n    health_status = {}\n    if obj.status ~= nil then\n      if obj.status.conditions\
+    \ upstream\n    -- See https://github.com/argoproj/argo-cd/blob/f3730da01ef05c0b7ae97385aca6642faf9e4c52/resource_customizations/operators.coreos.com/Subscription/health.lua\n\
+    \    health_status = {}\n    if obj.status ~= nil then\n      if obj.status.conditions\
     \ ~= nil then\n        numDegraded = 0\n        numPending = 0\n        msg =\
     \ \"\"\n        for i, condition in pairs(obj.status.conditions) do\n        \
     \  msg = msg .. i .. \": \" .. condition.type .. \" | \" .. condition.status ..\
@@ -32,10 +33,12 @@ data:
     \ == \"True\" then\n            numPending = numPending + 1\n          elseif\
     \ (condition.type == \"CatalogSourcesUnhealthy\" or condition.type == \"InstallPlanMissing\"\
     \ or condition.type == \"InstallPlanFailed\" or condition.type == \"ResolutionFailed\"\
-    ) and condition.status == \"True\" then\n            if condition.type == \"ResolutionFailed\"\
-    \  and condition.reason == \"ConstraintsNotSatisfiable\" and string.find(condition.message,\
-    \ \"cilium%-enterprise\") then\n              msg = msg .. \"; Ignoring ConstraintsNotSatisfiable\
-    \ for cilium-enterprise subscription\"\n            else\n              numDegraded\
+    ) and condition.status == \"True\" then\n            -- Custom check to ignore\
+    \ ConstraintsNotSatisfiable for\n            -- cilium-enterprise subscription.\n\
+    \            if condition.type == \"ResolutionFailed\"  and condition.reason ==\
+    \ \"ConstraintsNotSatisfiable\" and string.find(condition.message, \"cilium%-enterprise\"\
+    ) then\n              msg = msg .. \"; Ignoring ConstraintsNotSatisfiable for\
+    \ cilium-enterprise subscription\"\n            else\n              numDegraded\
     \ = numDegraded + 1\n            end\n          end\n        end\n        if numDegraded\
     \ == 0 and numPending == 0 then\n          health_status.status = \"Healthy\"\n\
     \          health_status.message = msg\n          return health_status\n     \

--- a/tests/golden/params/argocd/argocd/10_config/10_argocd-cm.yaml
+++ b/tests/golden/params/argocd/argocd/10_config/10_argocd-cm.yaml
@@ -22,7 +22,30 @@ data:
     Healthy\"\n        else\n          hs.status = \"Degraded\"\n        end\n   \
     \     hs.message = installed_message .. \" \" .. healthy_message\n        return\
     \ hs\n      end\n    end\n\n    hs.status = \"Progressing\"\n    hs.message =\
-    \ \"Waiting for provider to be installed\"\n    return hs\n"
+    \ \"Waiting for provider to be installed\"\n    return hs\noperators.coreos.com/Subscription:\n\
+    \  health.lua.useOpenLibs: true\n  health.lua: |\n    -- Base check copied from\
+    \ upstream\n    health_status = {}\n    if obj.status ~= nil then\n      if obj.status.conditions\
+    \ ~= nil then\n        numDegraded = 0\n        numPending = 0\n        msg =\
+    \ \"\"\n        for i, condition in pairs(obj.status.conditions) do\n        \
+    \  msg = msg .. i .. \": \" .. condition.type .. \" | \" .. condition.status ..\
+    \ \"\\n\"\n          if condition.type == \"InstallPlanPending\" and condition.status\
+    \ == \"True\" then\n            numPending = numPending + 1\n          elseif\
+    \ (condition.type == \"CatalogSourcesUnhealthy\" or condition.type == \"InstallPlanMissing\"\
+    \ or condition.type == \"InstallPlanFailed\" or condition.type == \"ResolutionFailed\"\
+    ) and condition.status == \"True\" then\n            if condition.type == \"ResolutionFailed\"\
+    \  and condition.reason == \"ConstraintsNotSatisfiable\" and string.find(condition.message,\
+    \ \"cilium%-enterprise\") then\n              msg = msg .. \"; Ignoring ConstraintsNotSatisfiable\
+    \ for cilium-enterprise subscription\"\n            else\n              numDegraded\
+    \ = numDegraded + 1\n            end\n          end\n        end\n        if numDegraded\
+    \ == 0 and numPending == 0 then\n          health_status.status = \"Healthy\"\n\
+    \          health_status.message = msg\n          return health_status\n     \
+    \   elseif numPending > 0 and numDegraded == 0 then\n          health_status.status\
+    \ = \"Progressing\"\n          health_status.message = \"An install plan for a\
+    \ subscription is pending installation\"\n          return health_status\n   \
+    \     else\n          health_status.status = \"Degraded\"\n          health_status.message\
+    \ = msg\n          return health_status\n        end\n      end\n    end\n   \
+    \ health_status.status = \"Progressing\"\n    health_status.message = \"An install\
+    \ plan for a subscription is pending installation\"\n    return health_status\n"
 kind: ConfigMap
 metadata:
   annotations: {}


### PR DESCRIPTION
We need a special-case for the cilium-enterprise subscription for https://github.com/projectsyn/component-cilium/pull/22, since that subscription isn't completely healthy out of the box.

The PR copies the Subscription health check from https://github.com/argoproj/argo-cd/blob/f3730da01ef05c0b7ae97385aca6642faf9e4c52/resource_customizations/operators.coreos.com/Subscription/health.lua and adds a custom condition to ignore the `ConstraintsNotSatisfiable` for the `ResolutionFailed` status for the `cilium-enterprise` subscription only.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
