### PR TITLE
Fix `mount_path` key location

### DIFF
--- a/component/repo-server.jsonnet
+++ b/component/repo-server.jsonnet
@@ -12,11 +12,11 @@ local vault_agent_config = kube.ConfigMap('vault-agent-config') {
   data: {
     'vault-agent-config.json': std.manifestJson({
       exit_after_auth: false,
-      [if std.objectHas(inv.parameters.secret_management, 'vault_auth_mount_path') then 'mount_path']: inv.parameters.secret_management.vault_auth_mount_path,
       auto_auth: {
         method: [
           {
             type: 'kubernetes',
+            [if std.objectHas(inv.parameters.secret_management, 'vault_auth_mount_path') then 'mount_path']: inv.parameters.secret_management.vault_auth_mount_path,
             config: {
               role: inv.parameters.secret_management.vault_role,
               token_path: '/var/run/secrets/syn/token',

--- a/tests/golden/defaults/argocd/argocd/30_repo-server/configmap.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_repo-server/configmap.yaml
@@ -3,13 +3,13 @@ data:
   vault-agent-config.json: "{\n    \"auto_auth\": {\n        \"method\": [\n     \
     \       {\n                \"config\": {\n                    \"role\": \"test\"\
     ,\n                    \"token_path\": \"/var/run/secrets/syn/token\"\n      \
-    \          },\n                \"type\": \"kubernetes\"\n            }\n     \
-    \   ],\n        \"sinks\": [\n            {\n                \"sink\": {\n   \
-    \                 \"config\": {\n                        \"mode\": 420,\n    \
-    \                    \"path\": \"/home/vault/.vault-token\"\n                \
-    \    },\n                    \"type\": \"file\"\n                }\n         \
-    \   }\n        ]\n    },\n    \"exit_after_auth\": false,\n    \"mount_path\"\
-    : \"auth/lieutenant\"\n}"
+    \          },\n                \"mount_path\": \"auth/lieutenant\",\n        \
+    \        \"type\": \"kubernetes\"\n            }\n        ],\n        \"sinks\"\
+    : [\n            {\n                \"sink\": {\n                    \"config\"\
+    : {\n                        \"mode\": 420,\n                        \"path\"\
+    : \"/home/vault/.vault-token\"\n                    },\n                    \"\
+    type\": \"file\"\n                }\n            }\n        ]\n    },\n    \"\
+    exit_after_auth\": false\n}"
 kind: ConfigMap
 metadata:
   annotations: {}


### PR DESCRIPTION
That was an obvious error. That's what I get when I try to quickly finish something at the end of a sprint...

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
