### PR TITLE
Ensure monitoring is enabled on OCP4 clusters

### DIFF
--- a/component/config.jsonnet
+++ b/component/config.jsonnet
@@ -8,6 +8,7 @@ local namespace = kube.Namespace(params.namespace) {
     labels+: {
       SYNMonitoring: 'main',
       'app.kubernetes.io/part-of': 'argocd',
+      'openshift.io/cluster-monitoring': 'true',
     },
   },
 };

--- a/tests/golden/defaults/argocd/argocd/10_config/00_namespace.yaml
+++ b/tests/golden/defaults/argocd/argocd/10_config/00_namespace.yaml
@@ -6,4 +6,5 @@ metadata:
     SYNMonitoring: main
     app.kubernetes.io/part-of: argocd
     name: syn
+    openshift.io/cluster-monitoring: 'true'
   name: syn

--- a/tests/golden/openshift/argocd/argocd/10_config/00_namespace.yaml
+++ b/tests/golden/openshift/argocd/argocd/10_config/00_namespace.yaml
@@ -6,4 +6,5 @@ metadata:
     SYNMonitoring: main
     app.kubernetes.io/part-of: argocd
     name: syn
+    openshift.io/cluster-monitoring: 'true'
   name: syn

--- a/tests/golden/params/argocd/argocd/10_config/00_namespace.yaml
+++ b/tests/golden/params/argocd/argocd/10_config/00_namespace.yaml
@@ -6,4 +6,5 @@ metadata:
     SYNMonitoring: main
     app.kubernetes.io/part-of: argocd
     name: syn
+    openshift.io/cluster-monitoring: 'true'
   name: syn


### PR DESCRIPTION
The built-in monitoring stack on OCP4 only respects Monitor- and
PrometheusRule resources in namespaces that are labelled accordingly.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.