### PR TITLE
Add monitoring labels to support component-prometheus

### DIFF
--- a/component/monitoring.libsonnet
+++ b/component/monitoring.libsonnet
@@ -1,5 +1,6 @@
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+local prometheus = import 'lib/prometheus.libsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.argocd;
 
@@ -96,9 +97,15 @@ local grafana_dashboard =
     },
   };
 
+local promEnable = function(obj)
+  if std.member(inv.applications, 'prometheus') then
+    prometheus.Enable(obj)
+  else obj
+;
+
 [
-  serviceMonitor('argocd-metrics'),
-  serviceMonitor('argocd-server-metrics'),
-  serviceMonitor('argocd-repo-server'),
-  alert_rules,
+  promEnable(serviceMonitor('argocd-metrics')),
+  promEnable(serviceMonitor('argocd-server-metrics')),
+  promEnable(serviceMonitor('argocd-repo-server')),
+  promEnable(alert_rules),
 ] + if params.monitoring.dashboards then [ grafana_dashboard ] else []

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,5 +1,17 @@
+applications:
+  - prometheus
+
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
   secret_management:
     vault_role: test
     vault_auth_mount_path: auth/lieutenant
     vault_addr: test.syn.tools
+
+  prometheus:
+    defaultInstance: infra

--- a/tests/golden/defaults/argocd/argocd/10_config/00_namespace.yaml
+++ b/tests/golden/defaults/argocd/argocd/10_config/00_namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     SYNMonitoring: main
     app.kubernetes.io/part-of: argocd
+    monitoring.syn.tools/infra: 'true'
     name: syn
     openshift.io/cluster-monitoring: 'true'
   name: syn

--- a/tests/golden/defaults/argocd/argocd/10_config/20_monitoring.yaml
+++ b/tests/golden/defaults/argocd/argocd/10_config/20_monitoring.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: argocd-metrics
     app.kubernetes.io/part-of: argocd
+    monitoring.syn.tools/enabled: 'true'
     name: argocd-metrics
   name: argocd-metrics
   namespace: syn
@@ -23,6 +24,7 @@ metadata:
   labels:
     app.kubernetes.io/name: argocd-server-metrics
     app.kubernetes.io/part-of: argocd
+    monitoring.syn.tools/enabled: 'true'
     name: argocd-server-metrics
   name: argocd-server-metrics
   namespace: syn
@@ -41,6 +43,7 @@ metadata:
   labels:
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
+    monitoring.syn.tools/enabled: 'true'
     name: argocd-repo-server
   name: argocd-repo-server
   namespace: syn
@@ -58,6 +61,7 @@ metadata:
   annotations: {}
   labels:
     cluster_id: c-green-test-1234
+    monitoring.syn.tools/enabled: 'true'
     name: argocd
     prometheus: platform
     role: alert-rules

--- a/tests/golden/openshift/argocd/argocd/10_config/00_namespace.yaml
+++ b/tests/golden/openshift/argocd/argocd/10_config/00_namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     SYNMonitoring: main
     app.kubernetes.io/part-of: argocd
+    monitoring.syn.tools/infra: 'true'
     name: syn
     openshift.io/cluster-monitoring: 'true'
   name: syn

--- a/tests/golden/openshift/argocd/argocd/10_config/20_monitoring.yaml
+++ b/tests/golden/openshift/argocd/argocd/10_config/20_monitoring.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: argocd-metrics
     app.kubernetes.io/part-of: argocd
+    monitoring.syn.tools/enabled: 'true'
     name: argocd-metrics
   name: argocd-metrics
   namespace: syn
@@ -23,6 +24,7 @@ metadata:
   labels:
     app.kubernetes.io/name: argocd-server-metrics
     app.kubernetes.io/part-of: argocd
+    monitoring.syn.tools/enabled: 'true'
     name: argocd-server-metrics
   name: argocd-server-metrics
   namespace: syn
@@ -41,6 +43,7 @@ metadata:
   labels:
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
+    monitoring.syn.tools/enabled: 'true'
     name: argocd-repo-server
   name: argocd-repo-server
   namespace: syn
@@ -58,6 +61,7 @@ metadata:
   annotations: {}
   labels:
     cluster_id: c-green-test-1234
+    monitoring.syn.tools/enabled: 'true'
     name: argocd
     prometheus: platform
     role: alert-rules

--- a/tests/openshift.yml
+++ b/tests/openshift.yml
@@ -1,7 +1,19 @@
+applications:
+  - prometheus
+
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
   secret_management:
     vault_role: test
     vault_addr: test.syn.tools
 
   facts:
     distribution: openshift4
+
+  prometheus:
+    defaultInstance: infra


### PR DESCRIPTION
The component `prometheus` supports cluster-monitoring, where the namespace, PrometheusRules and monitors need a specific label.

This commit will add the required labels.

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>




## Checklist

- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
