### PR TITLE
Disable automatic pruning for ArgoCD app

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -30,7 +30,15 @@ local root_app = argocd.App('root', params.namespace, secrets=false) {
   },
 };
 
-local app = argocd.App('argocd', params.namespace, secrets=false);
+local app = argocd.App('argocd', params.namespace, secrets=false) {
+  spec+: {
+    syncPolicy+: {
+      automated+: {
+        prune: false,
+      },
+    },
+  },
+};
 
 {
   '00_syn-project': syn_project,

--- a/docs/modules/ROOT/pages/how-tos/upgrade-v5-v6.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-v5-v6.adoc
@@ -2,7 +2,7 @@
 
 == Migration to ArgoCD Operator
 
-As of version 6, the ArgoCD operator is used to manage ArgoCD on the cluster.
+As of component version 6, the ArgoCD operator is used to manage ArgoCD on the cluster.
 To avoid ArgoCD becoming unavailable during the migration, it has to be prevented from pruning itself until the migration is complete.
 
 
@@ -12,13 +12,13 @@ component-argocd v5.5.0 or higher disables auto-pruning by default.
 This is required for the migration to succeed.
 Ensure your cluster uses component-argocd v5.5.0 or higher.
 
-=== 2. Ensure steward version v0.9.0 or higher is installed on the cluster
+=== 2. Ensure Steward version v0.9.0 or higher is installed on the cluster
 
-Steward supports the migration to component-argocd v6.x starting from steward version v0.9.0.
-Older versions of steward will interfere with the operator-managed ArgoCD deployment.
+Steward v0.9.0 and newer supports the migration to component-argocd v6.x.
+Older versions of Steward will interfere with the operator-managed ArgoCD deployment.
 
 Steward version v0.9.0 is introduced in component-steward v3.6.0.
-If you manage steward via Project Syn, ensure that component-steward v3.6.0 or higher is rolled out on the cluster.
+If you manage Steward via Project Syn, ensure that component-steward v3.6.0 or higher is rolled out on the cluster.
 
 === 3. Upgrade component-argocd with migration flag
 

--- a/docs/modules/ROOT/pages/how-tos/upgrade-v5-v6.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-v5-v6.adoc
@@ -1,0 +1,41 @@
+= Upgrade `component-argocd` from `v5.5.x` to `v6.x`
+
+== Migration to ArgoCD Operator
+
+As of version 6, the ArgoCD operator is used to manage ArgoCD on the cluster.
+To avoid ArgoCD becoming unavailable during the migration, it has to be prevented from pruning itself until the migration is complete.
+
+
+=== 1. Ensure component-argocd version v5.5.0 or higher is rolled out
+
+component-argocd v5.5.0 or higher disables auto-pruning by default.
+This is required for the migration to succeed.
+Ensure your cluster uses component-argocd v5.5.0 or higher.
+
+=== 2. Ensure steward version v0.9.0 or higher is installed on the cluster
+
+Steward supports the migration to component-argocd v6.x starting from steward version v0.9.0.
+Older versions of steward will interfere with the operator-managed ArgoCD deployment.
+
+Steward version v0.9.0 is introduced in component-steward v3.6.0.
+If you manage steward via Project Syn, ensure that component-steward v3.6.0 or higher is rolled out on the cluster.
+
+=== 3. Upgrade component-argocd with migration flag
+
+The first time you roll out component-argocd v6.x, set the following configuration in your hierarchy:
+
+[source,yaml]
+----
+parameters:
+  argocd:
+    operator:
+      migrate: true
+----
+
+Roll out the upgrade with this configuration, and wait until the new pods for `syn-argocd` appear in the configured namespace.
+
+=== 4. Remove the migration flag to complete the migration
+
+After the first rollout of v6.x, the migration flag can be removed.
+Once this change is rolled out, ArgoCD can become unavailable for up to 15 minutes, after which it should recover without manual intervention.
+

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -2,6 +2,7 @@
 
 .How-tos
 * xref:how-tos/upgrade-v3-v4.adoc[Upgrade from `v3.x` to `v4.x`]
+* xref:how-tos/upgrade-v5-v6.adoc[Upgrade from `v5.5.x` to `v6.x`]
 
 .References
 * xref:references/parameters.adoc[Parameters]

--- a/tests/golden/defaults/argocd/apps/10_argocd.yaml
+++ b/tests/golden/defaults/argocd/apps/10_argocd.yaml
@@ -18,5 +18,5 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: true

--- a/tests/golden/openshift/argocd/apps/10_argocd.yaml
+++ b/tests/golden/openshift/argocd/apps/10_argocd.yaml
@@ -18,5 +18,5 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: true

--- a/tests/golden/params/argocd/apps/10_argocd.yaml
+++ b/tests/golden/params/argocd/apps/10_argocd.yaml
@@ -18,5 +18,5 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: true


### PR DESCRIPTION
In preparation for the migration to operator-managed ArgoCD, we have to prevent ArgoCD from pruning itself prematurely. This flag will be disabled again once the migration is complete. I don't expect issues until then, as there aren't any other planned changes for the component.

The migration will be in three steps:
1. Ensure this version with `prune: false` is rolled out and that Steward is on a recent enough version (to be released)
2. Upgrade to operator-managed but set the `migrate: true` parameter
3. Remove the `migrate: true` parameter and roll out again

~A migration guide would probably be good, though I'm not sure where to put it.~ Migration guide is part of this PR

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
