### PR TITLE
Implement Kapitan plugin as ConfigMamangementPlugin sidecar

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -23,8 +23,8 @@ parameters:
         tag: '1.28.4@sha256:9aa77d80cf5d32e0345c8468a45d39134a8016e30eccddaf720bf197ad7dd9f0'
       kapitan:
         registry: docker.io
-        repository: projectsyn/kapitan
-        tag: 'v0.29.5@sha256:33715063f8238a93938f79053bc939e992def3bbe95ae1f9f6e48e5c1421d569'
+        repository: kapicorp/kapitan
+        tag: 'v0.32.0'
       vault_agent:
         registry: docker.io
         repository: library/vault

--- a/component/argocd.jsonnet
+++ b/component/argocd.jsonnet
@@ -135,6 +135,12 @@ local repoServer = {
   sidecarContainers: [
     kube.Container('kapitan') {
       command: [ '/var/run/argocd/argocd-cmp-server' ],
+      args: [
+        '--loglevel',
+        $.logLevel,
+        '--logformat',
+        $.logFormat,
+      ],
       env_: {
         HOME: '/home/argocd',
       },

--- a/component/argocd.jsonnet
+++ b/component/argocd.jsonnet
@@ -65,6 +65,33 @@ local vault_agent_config = kube.ConfigMap('vault-agent-config') {
   },
 };
 
+local kapitan_plugin_config = kube.ConfigMap('kapitan-plugin-config') {
+  data: {
+    'plugin.yaml': std.manifestYamlDoc(
+      {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ConfigManagementPlugin',
+        metadata: {
+          name: 'kapitan',
+        },
+        spec: {
+          generate: {
+            command: [
+              'kapitan',
+              'refs',
+              '--reveal',
+              '--refs-path',
+              '../../refs/',
+              '--file',
+              './',
+            ],
+          },
+        },
+      }
+    ),
+  },
+};
+
 local repoServer = {
   logLevel: common.evaluate_log_level('repo_server'),
   logFormat: common.evaluate_log_format('repo_server'),
@@ -75,20 +102,11 @@ local repoServer = {
     std.prune(params.resources.repo_server),
   volumeMounts: [
     {
-      name: 'kapitan-bin',
-      mountPath: '/usr/local/bin/kapitan',
-      subPath: 'kapitan',
-    },
-    {
       name: 'vault-token',
       mountPath: '/home/argocd/',
     },
   ],
   volumes: [
-    {
-      name: 'kapitan-bin',
-      emptyDir: {},
-    },
     {
       name: 'vault-token',
       emptyDir: {
@@ -107,25 +125,39 @@ local repoServer = {
         secretName: 'steward',
       },
     },
-  ],
-  initContainers: [
     {
-      name: 'install-kapitan',
-      image: common.render_image('kapitan', include_tag=true),
-      imagePullPolicy: 'Always',
-      command: [
-        'cp',
-        '-v',
-        '/usr/local/bin/kapitan',
-        '/custom-tools/',
-      ],
-      volumeMounts: [ {
-        name: 'kapitan-bin',
-        mountPath: '/custom-tools',
-      } ],
+      name: 'kapitan-plugin-config',
+      configMap: {
+        name: kapitan_plugin_config.metadata.name,
+      },
     },
   ],
   sidecarContainers: [
+    kube.Container('kapitan') {
+      command: [ '/var/run/argocd/argocd-cmp-server' ],
+      env_: {
+        HOME: '/home/argocd',
+      },
+      image: common.render_image('kapitan', include_tag=true),
+      securityContext: {
+        runAsNonRoot: true,
+      },
+      volumeMounts_: {
+        'var-files': {
+          mountPath: '/var/run/argocd',
+        },
+        plugins: {
+          mountPath: '/home/argocd/cmp-server/plugins',
+        },
+        kapitan_plugin_config: {
+          mountPath: '/home/argocd/cmp-server/config/plugin.yaml',
+          subPath: 'plugin.yaml',
+        },
+        'vault-token': {
+          mountPath: '/home/argocd/',
+        },
+      },
+    },
     kube.Container('vault-agent') {
       name: 'vault-agent',
       image: common.render_image('vault_agent', include_tag=true),
@@ -171,11 +203,6 @@ local argocd(name) =
       image: common.render_image('argocd'),
       version: params.images.argocd.tag,
       applicationInstanceLabelKey: 'argocd.argoproj.io/instance',
-      configManagementPlugins: |||
-        - name: kapitan
-          generate:
-            command: [kapitan, refs, --reveal, --refs-path, ../../refs/, --file, ./]
-      |||,
       controller: applicationController,
       initialRepositories: '- url: ' + inv.parameters.cluster.catalog_url,
       repositoryCredentials: |||
@@ -313,6 +340,7 @@ local ssh_secret = kube._Object('v1', 'Secret', 'argo-ssh-key') {
 
 {
   '00_vault_agent_config': vault_agent_config,
+  '00_kapitan_plugin_config': kapitan_plugin_config,
   '00_ssh_secret': ssh_secret,
   '10_argocd': argocd('syn-argocd'),
 }

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -10,7 +10,7 @@ local evaluate_log_format = function(component)
 local render_image(imagename, include_tag=false) =
   local imagespec = params.images[imagename];
   local image =
-    if std.objectHas(imagespec, 'image') then
+    if std.objectHas(imagespec, 'image') && imagespec.image != null then
       std.trace(
         'Field `image` for selecting the container image `%s` has been deprecated in favor of fields `registry` and `repository`, please update your config' % imagename,
         imagespec.image

--- a/tests/golden/defaults/argocd/argocd/30_argocd/00_kapitan_plugin_config.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/00_kapitan_plugin_config.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+  plugin.yaml: |-
+    "apiVersion": "argoproj.io/v1alpha1"
+    "kind": "ConfigManagementPlugin"
+    "metadata":
+      "name": "kapitan"
+    "spec":
+      "generate":
+        "command":
+        - "kapitan"
+        - "refs"
+        - "--reveal"
+        - "--refs-path"
+        - "../../refs/"
+        - "--file"
+        - "./"
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: kapitan-plugin-config
+  name: kapitan-plugin-config

--- a/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
@@ -9,10 +9,6 @@ metadata:
   namespace: syn
 spec:
   applicationInstanceLabelKey: argocd.argoproj.io/instance
-  configManagementPlugins: |
-    - name: kapitan
-      generate:
-        command: [kapitan, refs, --reveal, --refs-path, ../../refs/, --file, ./]
   controller:
     appSync: 180s
     logFormat: text
@@ -53,18 +49,6 @@ spec:
     env:
       - name: HOME
         value: /home/argocd
-    initContainers:
-      - command:
-          - cp
-          - -v
-          - /usr/local/bin/kapitan
-          - /custom-tools/
-        image: docker.io/projectsyn/kapitan:v0.29.5@sha256:33715063f8238a93938f79053bc939e992def3bbe95ae1f9f6e48e5c1421d569
-        imagePullPolicy: Always
-        name: install-kapitan
-        volumeMounts:
-          - mountPath: /custom-tools
-            name: kapitan-bin
     logFormat: text
     logLevel: info
     resources:
@@ -74,6 +58,30 @@ spec:
         cpu: 10m
         memory: 128Mi
     sidecarContainers:
+      - args: []
+        command:
+          - /var/run/argocd/argocd-cmp-server
+        env:
+          - name: HOME
+            value: /home/argocd
+        image: docker.io/kapicorp/kapitan:v0.32.0
+        imagePullPolicy: IfNotPresent
+        name: kapitan
+        ports: []
+        securityContext:
+          runAsNonRoot: true
+        stdin: false
+        tty: false
+        volumeMounts:
+          - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+            name: kapitan-plugin-config
+            subPath: plugin.yaml
+          - mountPath: /home/argocd/cmp-server/plugins
+            name: plugins
+          - mountPath: /var/run/argocd
+            name: var-files
+          - mountPath: /home/argocd/
+            name: vault-token
       - args:
           - agent
           - -config
@@ -104,14 +112,9 @@ spec:
           - mountPath: /home/vault/
             name: vault-token
     volumeMounts:
-      - mountPath: /usr/local/bin/kapitan
-        name: kapitan-bin
-        subPath: kapitan
       - mountPath: /home/argocd/
         name: vault-token
     volumes:
-      - emptyDir: {}
-        name: kapitan-bin
       - emptyDir:
           medium: Memory
         name: vault-token
@@ -121,6 +124,9 @@ spec:
       - name: steward-token
         secret:
           secretName: steward
+      - configMap:
+          name: kapitan-plugin-config
+        name: kapitan-plugin-config
   repositoryCredentials: |
     - url: ssh://git@
       sshPrivateKeySecret:

--- a/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
@@ -58,7 +58,11 @@ spec:
         cpu: 10m
         memory: 128Mi
     sidecarContainers:
-      - args: []
+      - args:
+          - --loglevel
+          - info
+          - --logformat
+          - text
         command:
           - /var/run/argocd/argocd-cmp-server
         env:

--- a/tests/golden/openshift/argocd/argocd/30_argocd/00_kapitan_plugin_config.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/00_kapitan_plugin_config.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+  plugin.yaml: |-
+    "apiVersion": "argoproj.io/v1alpha1"
+    "kind": "ConfigManagementPlugin"
+    "metadata":
+      "name": "kapitan"
+    "spec":
+      "generate":
+        "command":
+        - "kapitan"
+        - "refs"
+        - "--reveal"
+        - "--refs-path"
+        - "../../refs/"
+        - "--file"
+        - "./"
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: kapitan-plugin-config
+  name: kapitan-plugin-config

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd.yaml
@@ -9,10 +9,6 @@ metadata:
   namespace: syn
 spec:
   applicationInstanceLabelKey: argocd.argoproj.io/instance
-  configManagementPlugins: |
-    - name: kapitan
-      generate:
-        command: [kapitan, refs, --reveal, --refs-path, ../../refs/, --file, ./]
   controller:
     appSync: 180s
     logFormat: text
@@ -53,18 +49,6 @@ spec:
     env:
       - name: HOME
         value: /home/argocd
-    initContainers:
-      - command:
-          - cp
-          - -v
-          - /usr/local/bin/kapitan
-          - /custom-tools/
-        image: docker.io/projectsyn/kapitan:v0.29.5@sha256:33715063f8238a93938f79053bc939e992def3bbe95ae1f9f6e48e5c1421d569
-        imagePullPolicy: Always
-        name: install-kapitan
-        volumeMounts:
-          - mountPath: /custom-tools
-            name: kapitan-bin
     logFormat: text
     logLevel: info
     resources:
@@ -74,6 +58,30 @@ spec:
         cpu: 10m
         memory: 128Mi
     sidecarContainers:
+      - args: []
+        command:
+          - /var/run/argocd/argocd-cmp-server
+        env:
+          - name: HOME
+            value: /home/argocd
+        image: docker.io/kapicorp/kapitan:v0.32.0
+        imagePullPolicy: IfNotPresent
+        name: kapitan
+        ports: []
+        securityContext:
+          runAsNonRoot: true
+        stdin: false
+        tty: false
+        volumeMounts:
+          - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+            name: kapitan-plugin-config
+            subPath: plugin.yaml
+          - mountPath: /home/argocd/cmp-server/plugins
+            name: plugins
+          - mountPath: /var/run/argocd
+            name: var-files
+          - mountPath: /home/argocd/
+            name: vault-token
       - args:
           - agent
           - -config
@@ -102,14 +110,9 @@ spec:
           - mountPath: /home/vault/
             name: vault-token
     volumeMounts:
-      - mountPath: /usr/local/bin/kapitan
-        name: kapitan-bin
-        subPath: kapitan
       - mountPath: /home/argocd/
         name: vault-token
     volumes:
-      - emptyDir: {}
-        name: kapitan-bin
       - emptyDir:
           medium: Memory
         name: vault-token
@@ -119,6 +122,9 @@ spec:
       - name: steward-token
         secret:
           secretName: steward
+      - configMap:
+          name: kapitan-plugin-config
+        name: kapitan-plugin-config
   repositoryCredentials: |
     - url: ssh://git@
       sshPrivateKeySecret:

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd.yaml
@@ -58,7 +58,11 @@ spec:
         cpu: 10m
         memory: 128Mi
     sidecarContainers:
-      - args: []
+      - args:
+          - --loglevel
+          - info
+          - --logformat
+          - text
         command:
           - /var/run/argocd/argocd-cmp-server
         env:

--- a/tests/golden/params/argocd/argocd/30_argocd/00_kapitan_plugin_config.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/00_kapitan_plugin_config.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+  plugin.yaml: |-
+    "apiVersion": "argoproj.io/v1alpha1"
+    "kind": "ConfigManagementPlugin"
+    "metadata":
+      "name": "kapitan"
+    "spec":
+      "generate":
+        "command":
+        - "kapitan"
+        - "refs"
+        - "--reveal"
+        - "--refs-path"
+        - "../../refs/"
+        - "--file"
+        - "./"
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: kapitan-plugin-config
+  name: kapitan-plugin-config

--- a/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
@@ -9,10 +9,6 @@ metadata:
   namespace: syn
 spec:
   applicationInstanceLabelKey: argocd.argoproj.io/instance
-  configManagementPlugins: |
-    - name: kapitan
-      generate:
-        command: [kapitan, refs, --reveal, --refs-path, ../../refs/, --file, ./]
   controller:
     appSync: 180s
     logFormat: text
@@ -43,21 +39,33 @@ spec:
     env:
       - name: HOME
         value: /home/argocd
-    initContainers:
-      - command:
-          - cp
-          - -v
-          - /usr/local/bin/kapitan
-          - /custom-tools/
-        image: mymirror.io/projectsyn/kapitan:v0.29.5@sha256:33715063f8238a93938f79053bc939e992def3bbe95ae1f9f6e48e5c1421d569
-        imagePullPolicy: Always
-        name: install-kapitan
-        volumeMounts:
-          - mountPath: /custom-tools
-            name: kapitan-bin
     logFormat: text
     logLevel: info
     sidecarContainers:
+      - args: []
+        command:
+          - /var/run/argocd/argocd-cmp-server
+        env:
+          - name: HOME
+            value: /home/argocd
+        image: mymirror.io/projectsyn/kapitan:v0.32.0
+        imagePullPolicy: IfNotPresent
+        name: kapitan
+        ports: []
+        securityContext:
+          runAsNonRoot: true
+        stdin: false
+        tty: false
+        volumeMounts:
+          - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+            name: kapitan-plugin-config
+            subPath: plugin.yaml
+          - mountPath: /home/argocd/cmp-server/plugins
+            name: plugins
+          - mountPath: /var/run/argocd
+            name: var-files
+          - mountPath: /home/argocd/
+            name: vault-token
       - args:
           - agent
           - -config
@@ -83,14 +91,9 @@ spec:
           - mountPath: /home/vault/
             name: vault-token
     volumeMounts:
-      - mountPath: /usr/local/bin/kapitan
-        name: kapitan-bin
-        subPath: kapitan
       - mountPath: /home/argocd/
         name: vault-token
     volumes:
-      - emptyDir: {}
-        name: kapitan-bin
       - emptyDir:
           medium: Memory
         name: vault-token
@@ -100,6 +103,9 @@ spec:
       - name: steward-token
         secret:
           secretName: steward
+      - configMap:
+          name: kapitan-plugin-config
+        name: kapitan-plugin-config
   repositoryCredentials: |
     - url: ssh://git@
       sshPrivateKeySecret:

--- a/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
@@ -42,7 +42,11 @@ spec:
     logFormat: text
     logLevel: info
     sidecarContainers:
-      - args: []
+      - args:
+          - --loglevel
+          - info
+          - --logformat
+          - text
         command:
           - /var/run/argocd/argocd-cmp-server
         env:


### PR DESCRIPTION
See also https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/#sidecar-plugin

With the sidecar plugin architecture, we can use the upstream Kapitan docker image, since we don't need to be able to mount a single `kapitan` binary into the argocd-repo-server container to implement the plugin.

Follow-up to #90 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
