### PR TITLE
Rename ServiceMonitors so they don't get deleted by operator

### DIFF
--- a/component/monitoring.libsonnet
+++ b/component/monitoring.libsonnet
@@ -104,8 +104,10 @@ local promEnable = function(obj)
 ;
 
 [
-  promEnable(serviceMonitor('syn-argocd-metrics')),
-  promEnable(serviceMonitor('syn-argocd-server-metrics')),
-  promEnable(serviceMonitor('syn-argocd-repo-server')),
+  // We explicitly select names for the service monitors which don't match the
+  // operator-generated names for instance syn-argocd
+  promEnable(serviceMonitor('syn-component-argocd-metrics')),
+  promEnable(serviceMonitor('syn-component-argocd-server-metrics')),
+  promEnable(serviceMonitor('syn-component-argocd-repo-server')),
   promEnable(alert_rules),
 ] + if params.monitoring.dashboards then [ grafana_dashboard ] else []

--- a/tests/golden/defaults/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/defaults/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -3,18 +3,18 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-argocd-metrics
+    app.kubernetes.io/name: syn-component-argocd-metrics
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
-    name: syn-argocd-metrics
-  name: syn-argocd-metrics
+    name: syn-component-argocd-metrics
+  name: syn-component-argocd-metrics
   namespace: syn
 spec:
   endpoints:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-argocd-metrics
+      app.kubernetes.io/name: syn-component-argocd-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -22,18 +22,18 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-argocd-server-metrics
+    app.kubernetes.io/name: syn-component-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
-    name: syn-argocd-server-metrics
-  name: syn-argocd-server-metrics
+    name: syn-component-argocd-server-metrics
+  name: syn-component-argocd-server-metrics
   namespace: syn
 spec:
   endpoints:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-argocd-server-metrics
+      app.kubernetes.io/name: syn-component-argocd-server-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -41,18 +41,18 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-argocd-repo-server
+    app.kubernetes.io/name: syn-component-argocd-repo-server
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
-    name: syn-argocd-repo-server
-  name: syn-argocd-repo-server
+    name: syn-component-argocd-repo-server
+  name: syn-component-argocd-repo-server
   namespace: syn
 spec:
   endpoints:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-argocd-repo-server
+      app.kubernetes.io/name: syn-component-argocd-repo-server
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/tests/golden/openshift/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/openshift/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -3,18 +3,18 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-argocd-metrics
+    app.kubernetes.io/name: syn-component-argocd-metrics
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
-    name: syn-argocd-metrics
-  name: syn-argocd-metrics
+    name: syn-component-argocd-metrics
+  name: syn-component-argocd-metrics
   namespace: syn
 spec:
   endpoints:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-argocd-metrics
+      app.kubernetes.io/name: syn-component-argocd-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -22,18 +22,18 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-argocd-server-metrics
+    app.kubernetes.io/name: syn-component-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
-    name: syn-argocd-server-metrics
-  name: syn-argocd-server-metrics
+    name: syn-component-argocd-server-metrics
+  name: syn-component-argocd-server-metrics
   namespace: syn
 spec:
   endpoints:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-argocd-server-metrics
+      app.kubernetes.io/name: syn-component-argocd-server-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -41,18 +41,18 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-argocd-repo-server
+    app.kubernetes.io/name: syn-component-argocd-repo-server
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
-    name: syn-argocd-repo-server
-  name: syn-argocd-repo-server
+    name: syn-component-argocd-repo-server
+  name: syn-component-argocd-repo-server
   namespace: syn
 spec:
   endpoints:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-argocd-repo-server
+      app.kubernetes.io/name: syn-component-argocd-repo-server
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/tests/golden/params/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/params/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -3,17 +3,17 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-argocd-metrics
+    app.kubernetes.io/name: syn-component-argocd-metrics
     app.kubernetes.io/part-of: argocd
-    name: syn-argocd-metrics
-  name: syn-argocd-metrics
+    name: syn-component-argocd-metrics
+  name: syn-component-argocd-metrics
   namespace: syn
 spec:
   endpoints:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-argocd-metrics
+      app.kubernetes.io/name: syn-component-argocd-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -21,17 +21,17 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-argocd-server-metrics
+    app.kubernetes.io/name: syn-component-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
-    name: syn-argocd-server-metrics
-  name: syn-argocd-server-metrics
+    name: syn-component-argocd-server-metrics
+  name: syn-component-argocd-server-metrics
   namespace: syn
 spec:
   endpoints:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-argocd-server-metrics
+      app.kubernetes.io/name: syn-component-argocd-server-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -39,17 +39,17 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-argocd-repo-server
+    app.kubernetes.io/name: syn-component-argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    name: syn-argocd-repo-server
-  name: syn-argocd-repo-server
+    name: syn-component-argocd-repo-server
+  name: syn-component-argocd-repo-server
   namespace: syn
 spec:
   endpoints:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-argocd-repo-server
+      app.kubernetes.io/name: syn-component-argocd-repo-server
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
We create our own ServiceMonitor resources, since the argocd-operator doesn't support creating ServiceMonitors without also deploying a Prometheus instance.

However, the operator will delete any ServiceMonitor which matches the name that it would generate for its managed ServiceMonitors if the Prometheus component is disabled, cf. https://github.com/argoproj-labs/argocd-operator/blob/17064c9b310785ab145747a367f7deb5507a572e/controllers/argocd/prometheus.go#L129-L136

This causes the component-managed ServiceMonitors to get deleted from time to time, and they get recreated after a while by an ArgoCD resync.

This commit circumvents the issue by renaming the component-managed ServiceMonitors so they don't get deleted by the operator.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
