### PR TITLE
Fix Kapitan plugin securityContext on non-Openshift clusters

### DIFF
--- a/component/argocd.jsonnet
+++ b/component/argocd.jsonnet
@@ -147,6 +147,11 @@ local repoServer = {
       image: common.render_image('kapitan', include_tag=true),
       securityContext: {
         runAsNonRoot: true,
+        // On non-OpenShift we use user 999, since the main repo-server
+        // container also uses user 999 and we need to make sure that the main
+        // repo-server container has write permissions on the cmp-server
+        // socket created by this container.
+        [if !isOpenshift then 'runAsUser']: 999,
       },
       volumeMounts_: {
         'var-files': {

--- a/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
@@ -74,6 +74,7 @@ spec:
         ports: []
         securityContext:
           runAsNonRoot: true
+          runAsUser: 999
         stdin: false
         tty: false
         volumeMounts:

--- a/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
@@ -58,6 +58,7 @@ spec:
         ports: []
         securityContext:
           runAsNonRoot: true
+          runAsUser: 999
         stdin: false
         tty: false
         volumeMounts:


### PR DESCRIPTION
Follow-up to #128 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
