### PR TITLE
Remove support for legacy `image` field for image specifications

### DIFF
--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -9,14 +9,15 @@ local evaluate_log_format = function(component)
 
 local render_image(imagename, include_tag=false) =
   local imagespec = params.images[imagename];
+  local img = '%(registry)s/%(repository)s' % imagespec;
   local image =
     if std.objectHas(imagespec, 'image') && imagespec.image != null then
       std.trace(
-        'Field `image` for selecting the container image `%s` has been deprecated in favor of fields `registry` and `repository`, please update your config' % imagename,
-        imagespec.image
+        'Field `image` for selecting the container image `%s` has been removed. Please use fields `registry` and `repository` instead' % imagename,
+        img
       )
     else
-      '%(registry)s/%(repository)s' % imagespec;
+      img;
   if include_tag then
     '%(image)s:%(tag)s' % { image: image, tag: imagespec.tag }
   else

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -41,6 +41,7 @@ SSH known hosts for Git servers.
 type:: dictionary
 
 Dictionary containing the container images used by this component.
+Each entry follows the https://syn.tools/syn/explanations/commodore-components/container-images.html[Commodore component best practices] for specifying container images.
 
 == `log_level`
 

--- a/tests/golden/params/argocd/argocd/25_hooks/hooks.yaml
+++ b/tests/golden/params/argocd/argocd/25_hooks/hooks.yaml
@@ -86,7 +86,7 @@ spec:
           env:
             - name: HOME
               value: /home
-          image: mymirror.io/kubectl:1.28.4@sha256:9aa77d80cf5d32e0345c8468a45d39134a8016e30eccddaf720bf197ad7dd9f0
+          image: docker.io/bitnami/kubectl:1.28.4@sha256:9aa77d80cf5d32e0345c8468a45d39134a8016e30eccddaf720bf197ad7dd9f0
           imagePullPolicy: IfNotPresent
           name: argocd-post-sync
           ports: []


### PR DESCRIPTION
The `image` field was deprecated in component version v6. We now remove the field, so we can do the roll out of ArgoCD v2.9 with the new Kapitan sidecar plugin which uses a different container image with as little manual configuration as possible.

Follow-up to #128 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
