### PR TITLE
Fix label selectors for ArgoCD servicemonitors

### DIFF
--- a/component/monitoring.libsonnet
+++ b/component/monitoring.libsonnet
@@ -4,8 +4,8 @@ local prometheus = import 'lib/prometheus.libsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.argocd;
 
-local serviceMonitor(name) =
-  kube._Object('monitoring.coreos.com/v1', 'ServiceMonitor', name) {
+local serviceMonitor(objname, name) =
+  kube._Object('monitoring.coreos.com/v1', 'ServiceMonitor', objname) {
     metadata+: {
       namespace: params.namespace,
       labels+: {
@@ -106,8 +106,8 @@ local promEnable = function(obj)
 [
   // We explicitly select names for the service monitors which don't match the
   // operator-generated names for instance syn-argocd
-  promEnable(serviceMonitor('syn-component-argocd-metrics')),
-  promEnable(serviceMonitor('syn-component-argocd-server-metrics')),
-  promEnable(serviceMonitor('syn-component-argocd-repo-server')),
+  promEnable(serviceMonitor('syn-component-argocd-metrics', 'syn-argocd-metrics')),
+  promEnable(serviceMonitor('syn-component-argocd-server-metrics', 'syn-argocd-server-metrics')),
+  promEnable(serviceMonitor('syn-component-argocd-repo-server', 'syn-argocd-repo-server')),
   promEnable(alert_rules),
 ] + if params.monitoring.dashboards then [ grafana_dashboard ] else []

--- a/tests/golden/defaults/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/defaults/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-component-argocd-metrics
+    app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
     name: syn-component-argocd-metrics
@@ -14,7 +14,7 @@ spec:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-component-argocd-metrics
+      app.kubernetes.io/name: syn-argocd-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -22,7 +22,7 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-component-argocd-server-metrics
+    app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
     name: syn-component-argocd-server-metrics
@@ -33,7 +33,7 @@ spec:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-component-argocd-server-metrics
+      app.kubernetes.io/name: syn-argocd-server-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -41,7 +41,7 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-component-argocd-repo-server
+    app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
     name: syn-component-argocd-repo-server
@@ -52,7 +52,7 @@ spec:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-component-argocd-repo-server
+      app.kubernetes.io/name: syn-argocd-repo-server
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/tests/golden/openshift/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/openshift/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-component-argocd-metrics
+    app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
     name: syn-component-argocd-metrics
@@ -14,7 +14,7 @@ spec:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-component-argocd-metrics
+      app.kubernetes.io/name: syn-argocd-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -22,7 +22,7 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-component-argocd-server-metrics
+    app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
     name: syn-component-argocd-server-metrics
@@ -33,7 +33,7 @@ spec:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-component-argocd-server-metrics
+      app.kubernetes.io/name: syn-argocd-server-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -41,7 +41,7 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-component-argocd-repo-server
+    app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
     monitoring.syn.tools/enabled: 'true'
     name: syn-component-argocd-repo-server
@@ -52,7 +52,7 @@ spec:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-component-argocd-repo-server
+      app.kubernetes.io/name: syn-argocd-repo-server
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/tests/golden/params/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/params/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-component-argocd-metrics
+    app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
     name: syn-component-argocd-metrics
   name: syn-component-argocd-metrics
@@ -13,7 +13,7 @@ spec:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-component-argocd-metrics
+      app.kubernetes.io/name: syn-argocd-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -21,7 +21,7 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-component-argocd-server-metrics
+    app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
     name: syn-component-argocd-server-metrics
   name: syn-component-argocd-server-metrics
@@ -31,7 +31,7 @@ spec:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-component-argocd-server-metrics
+      app.kubernetes.io/name: syn-argocd-server-metrics
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -39,7 +39,7 @@ kind: ServiceMonitor
 metadata:
   annotations: {}
   labels:
-    app.kubernetes.io/name: syn-component-argocd-repo-server
+    app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
     name: syn-component-argocd-repo-server
   name: syn-component-argocd-repo-server
@@ -49,7 +49,7 @@ spec:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: syn-component-argocd-repo-server
+      app.kubernetes.io/name: syn-argocd-repo-server
       app.kubernetes.io/part-of: argocd
 ---
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
We renamed the ServiceMonitors in #129 without verifying that the renamed service monitors still discover any endpoints.

We need to split the ServiceMonitor name from the name used for the label selector to ensure that we can use an object name which doesn't collide with the operator-managed name, while still picking up the endpoints.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
