### PR TITLE
Support server-side apply through argocd library

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -33,9 +33,6 @@ local root_app = argocd.App('root', params.namespace, secrets=false) {
 local app = argocd.App('argocd', params.namespace, secrets=false) {
   spec+: {
     syncPolicy+: {
-      syncOptions+: [
-        'ServerSideApply=true',
-      ],
       automated+: {
         [if params.operator.migrate then 'prune' else null]: false,
       },

--- a/lib/argocd.libjsonnet
+++ b/lib/argocd.libjsonnet
@@ -50,6 +50,9 @@ local ArgoApp(component, namespace, project='syn', secrets=true) = {
         prune: true,
         selfHeal: true,
       },
+      syncOptions: [
+        'ServerSideApply=true',
+      ],
     },
     destination: {
       server: 'https://kubernetes.default.svc',

--- a/tests/golden/defaults/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/defaults/argocd/apps/01_rootapp.yaml
@@ -18,3 +18,5 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/tests/golden/openshift/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/openshift/argocd/apps/01_rootapp.yaml
@@ -18,3 +18,5 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/tests/golden/params/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/params/argocd/apps/01_rootapp.yaml
@@ -18,3 +18,5 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - ServerSideApply=true


### PR DESCRIPTION
ArgoCD operator does not support setting additional arguments to the application-controller. This feature will set the server-side apply option by updating the library.

By default all components use the library to create the application resource. This will enable the feature with the next catalog compilation.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
