### PR TITLE
Default values for AppProjects

### DIFF
--- a/component/instances.jsonnet
+++ b/component/instances.jsonnet
@@ -65,9 +65,11 @@ local argocds = std.foldl(
 // Gather AppProject instances
 local projects = std.mapWithKey(function(k, v) std.get(v, 'projects', {}), instances);
 
+local projectDefaults = std.mapWithKey(function(k, v) std.get(v, 'projectDefaults', {}), instances);
+
 // Flatten AppProjects, generating a namespaced name as the key
 local appprojects = {
-  [namespacedName(argocd).namespace + '/' + project]: projects[argocd][project]
+  [namespacedName(argocd).namespace + '/' + project]+: std.mergePatch(projectDefaults[argocd], projects[argocd][project])
   for argocd in std.objectFields(projects)
   for project in std.objectFields(projects[argocd])
   // remove nulled objects

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -265,3 +265,12 @@ Arbitrary `AppProject` instances to be deployed on the cluster.
 The keys of this parameter are used as the generated resource's `metadata.name`, while the parent `ArgoCD`'s namespace will be inherited.
 
 See https://argo-cd.readthedocs.io/en/stable/user-guide/projects/[the `AppProject` reference of Argo CD] for available fields.
+
+
+=== `instances.<namespace>/<name>.projectDefaults`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+Default values that will be applied for all `AppProjects` created for this instance.

--- a/tests/golden/params/argocd/argocd/90_instances/10_approjects.yaml
+++ b/tests/golden/params/argocd/argocd/90_instances/10_approjects.yaml
@@ -9,8 +9,10 @@ metadata:
 spec:
   clusterResourceWhitelist: []
   destinations:
-    - namespace: cust-*
+    - namespace: other-*
       server: https://kubernetes.default.svc
+  sourceNamespaces:
+    - two
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -25,3 +27,5 @@ spec:
   destinations:
     - namespace: corp-*
       server: https://kubernetes.default.svc
+  sourceNamespaces:
+    - one

--- a/tests/params.yml
+++ b/tests/params.yml
@@ -59,17 +59,24 @@ parameters:
                 tls:
                   termination: reencrypt
             version: v2.10.1
+
+        projectDefaults:
+          spec:
+            clusterResourceWhitelist: []
+            destinations:
+              - namespace: corp-*
+                server: https://kubernetes.default.svc
+
         projects:
           nulled-project: null
           some-project:
             spec:
-              clusterResourceWhitelist: []
-              destinations:
-                - namespace: corp-*
-                  server: https://kubernetes.default.svc
+              sourceNamespaces:
+                - one
           other-project:
             spec:
-              clusterResourceWhitelist: []
+              sourceNamespaces:
+                - two
               destinations:
-                - namespace: cust-*
+                - namespace: other-*
                   server: https://kubernetes.default.svc


### PR DESCRIPTION
In many use cases, the AppProject actually look quite similar, or at least include common things (like setting `clusterResourceWhitelist: []` to disallow the creation of cluster-scoped resources entirely).

This commit adds the `projectDefaults` field to ArgoCD instances, allowing users to -- who would have guessed it -- set defaults for their projects.

Follow-up to #151 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
