### PR TITLE
Fix empty `metadata.annotations` causing sync issues

### DIFF
--- a/component/instances.jsonnet
+++ b/component/instances.jsonnet
@@ -16,7 +16,11 @@ local namespacedName(name, namespace='') = {
 local ArgoCD(name) =
   local n = namespacedName(name);
   kube._Object('argoproj.io/v1beta1', 'ArgoCD', n.name) {
-    metadata+: {
+    metadata: {
+      labels: {
+        name: n.name,
+      },
+      name: n.name,
       namespace: n.namespace,
     },
     spec+: {
@@ -27,7 +31,11 @@ local ArgoCD(name) =
 local AppProject(name) =
   local n = namespacedName(name);
   kube._Object('argoproj.io/v1alpha1', 'AppProject', n.name) {
-    metadata+: {
+    metadata: {
+      labels: {
+        name: n.name,
+      },
+      name: n.name,
       namespace: n.namespace,
     },
   };

--- a/component/monitoring.libsonnet
+++ b/component/monitoring.libsonnet
@@ -6,9 +6,11 @@ local params = inv.parameters.argocd;
 
 local serviceMonitor(objname, name) =
   kube._Object('monitoring.coreos.com/v1', 'ServiceMonitor', objname) {
-    metadata+: {
+    metadata: {
+      name: objname,
       namespace: params.namespace,
-      labels+: {
+      labels: {
+        name: objname,
         'app.kubernetes.io/name': name,
         'app.kubernetes.io/part-of': 'argocd',
       },
@@ -28,9 +30,11 @@ local serviceMonitor(objname, name) =
 
 local alert_rules =
   kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', 'argocd') {
-    metadata+: {
+    metadata: {
+      name: 'argocd',
       namespace: params.namespace,
-      labels+: {
+      labels: {
+        name: 'argocd',
         role: 'alert-rules',
       } + params.monitoring.prometheus_rule_labels,
     },
@@ -88,8 +92,12 @@ local alert_rules =
 
 local grafana_dashboard =
   kube._Object('integreatly.org/v1alpha1', 'GrafanaDashboard', 'argocd') {
-    metadata+: {
+    metadata: {
+      name: 'argocd',
       namespace: params.namespace,
+      labels: {
+        name: 'argocd',
+      },
     },
     spec: {
       name: 'argocd',

--- a/component/rbac.jsonnet
+++ b/component/rbac.jsonnet
@@ -12,8 +12,10 @@ local custom_resources = {
 
 local aggregated_rbac = [
   kube.ClusterRole('syn-argocd-view') {
-    metadata+: {
-      labels+: {
+    metadata: {
+      name: 'syn-argocd-view',
+      labels: {
+        name: 'syn-argocd-view',
         'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
         'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
         'rbac.authorization.k8s.io/aggregate-to-view': 'true',
@@ -30,8 +32,10 @@ local aggregated_rbac = [
     ],
   },
   kube.ClusterRole('syn-argocd-edit') {
-    metadata+: {
-      labels+: {
+    metadata: {
+      name: 'syn-argocd-edit',
+      labels: {
+        name: 'syn-argocd-edit',
         'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
         'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
       },

--- a/tests/golden/defaults/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/defaults/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -1,7 +1,6 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  annotations: {}
   labels:
     app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
@@ -20,7 +19,6 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  annotations: {}
   labels:
     app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
@@ -39,7 +37,6 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  annotations: {}
   labels:
     app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
@@ -58,7 +55,6 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  annotations: {}
   labels:
     cluster_id: c-green-test-1234
     monitoring.syn.tools/enabled: 'true'

--- a/tests/golden/defaults/argocd/argocd/20_rbac/syn-argocd-edit-clusterrole.yaml
+++ b/tests/golden/defaults/argocd/argocd/20_rbac/syn-argocd-edit-clusterrole.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations: {}
   labels:
     name: syn-argocd-edit
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'

--- a/tests/golden/defaults/argocd/argocd/20_rbac/syn-argocd-view-clusterrole.yaml
+++ b/tests/golden/defaults/argocd/argocd/20_rbac/syn-argocd-view-clusterrole.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations: {}
   labels:
     name: syn-argocd-view
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'

--- a/tests/golden/openshift/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/openshift/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -1,7 +1,6 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  annotations: {}
   labels:
     app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
@@ -20,7 +19,6 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  annotations: {}
   labels:
     app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
@@ -39,7 +37,6 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  annotations: {}
   labels:
     app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
@@ -58,7 +55,6 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  annotations: {}
   labels:
     cluster_id: c-green-test-1234
     monitoring.syn.tools/enabled: 'true'

--- a/tests/golden/openshift/argocd/argocd/20_rbac/syn-argocd-edit-clusterrole.yaml
+++ b/tests/golden/openshift/argocd/argocd/20_rbac/syn-argocd-edit-clusterrole.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations: {}
   labels:
     name: syn-argocd-edit
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'

--- a/tests/golden/openshift/argocd/argocd/20_rbac/syn-argocd-view-clusterrole.yaml
+++ b/tests/golden/openshift/argocd/argocd/20_rbac/syn-argocd-view-clusterrole.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations: {}
   labels:
     name: syn-argocd-view
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'

--- a/tests/golden/params/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/params/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -1,7 +1,6 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  annotations: {}
   labels:
     app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
@@ -19,7 +18,6 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  annotations: {}
   labels:
     app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
@@ -37,7 +35,6 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  annotations: {}
   labels:
     app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
@@ -55,7 +52,6 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  annotations: {}
   labels:
     cluster_id: c-green-test-1234
     name: argocd

--- a/tests/golden/params/argocd/argocd/20_rbac/syn-argocd-edit-clusterrole.yaml
+++ b/tests/golden/params/argocd/argocd/20_rbac/syn-argocd-edit-clusterrole.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations: {}
   labels:
     name: syn-argocd-edit
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'

--- a/tests/golden/params/argocd/argocd/20_rbac/syn-argocd-view-clusterrole.yaml
+++ b/tests/golden/params/argocd/argocd/20_rbac/syn-argocd-view-clusterrole.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations: {}
   labels:
     name: syn-argocd-view
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'

--- a/tests/golden/params/argocd/argocd/90_instances/00_argocds.yaml
+++ b/tests/golden/params/argocd/argocd/90_instances/00_argocds.yaml
@@ -1,7 +1,6 @@
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  annotations: {}
   labels:
     name: some-argocd
   name: some-argocd
@@ -30,7 +29,6 @@ spec:
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  annotations: {}
   labels:
     name: foo
   name: foo

--- a/tests/golden/params/argocd/argocd/90_instances/10_approjects.yaml
+++ b/tests/golden/params/argocd/argocd/90_instances/10_approjects.yaml
@@ -1,7 +1,6 @@
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  annotations: {}
   labels:
     name: other-project
   name: other-project
@@ -17,7 +16,6 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  annotations: {}
   labels:
     name: some-project
   name: some-project


### PR DESCRIPTION
Switching this component to server-side has the side effect that the last known state is no longer tracked in the `metdata.annotations` field. If using a library to create resources, like `kube.libsonnet`, will create empty `metadata.annotations` fields. Which will then cause a sync issue with argocd.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
