### PR TITLE
Remove `hook=PostSync` annotation from hook RBAC

### DIFF
--- a/component/hooks.jsonnet
+++ b/component/hooks.jsonnet
@@ -10,9 +10,6 @@ local name = 'argocd-hooks';
 local role = kube.Role(name) {
   metadata+: {
     namespace: params.namespace,
-    annotations+: {
-      'argocd.argoproj.io/hook': 'PostSync',
-    },
   },
   rules: [
     {
@@ -31,18 +28,12 @@ local role = kube.Role(name) {
 local serviceAccount = kube.ServiceAccount(name) {
   metadata+: {
     namespace: params.namespace,
-    annotations+: {
-      'argocd.argoproj.io/hook': 'PostSync',
-    },
   },
 };
 
 local roleBinding = kube.RoleBinding(name) {
   metadata+: {
     namespace: params.namespace,
-    annotations+: {
-      'argocd.argoproj.io/hook': 'PostSync',
-    },
   },
   subjects_: [ serviceAccount ],
   roleRef_: role,

--- a/tests/golden/defaults/argocd/argocd/25_hooks/hooks.yaml
+++ b/tests/golden/defaults/argocd/argocd/25_hooks/hooks.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks
@@ -31,8 +30,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks
@@ -41,8 +39,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks

--- a/tests/golden/openshift/argocd/argocd/25_hooks/hooks.yaml
+++ b/tests/golden/openshift/argocd/argocd/25_hooks/hooks.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks
@@ -31,8 +30,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks
@@ -41,8 +39,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks

--- a/tests/golden/params/argocd/argocd/25_hooks/hooks.yaml
+++ b/tests/golden/params/argocd/argocd/25_hooks/hooks.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks
@@ -31,8 +30,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks
@@ -41,8 +39,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks

--- a/tests/golden/prometheus/argocd/argocd/25_hooks/hooks.yaml
+++ b/tests/golden/prometheus/argocd/argocd/25_hooks/hooks.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks
@@ -31,8 +30,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks
@@ -41,8 +39,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
+  annotations: {}
   labels:
     name: argocd-hooks
   name: argocd-hooks


### PR DESCRIPTION
This should fix the intermittent KubeJobFailed alerts for the post-sync hook job, since the job sometimes fails because the ServiceAccount and RBAC rules are missing.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
