### PR TITLE
Exclude `CiliumIdentity` resources from sync

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -88,6 +88,16 @@ parameters:
       gitlab-dev.syn.tools ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDybOH3scUSfAJFkskpVn1VcL1mPNSiV05asrCCjDTzSJOeJuCE99KkHf7eTA29as9NaqtMtJcCxhptLfNaRzUR3zf29eUuPhkh2B5PUaqLpsbm6330QxvWsZNJyI8Cf7i78O3qe4dv7p2Fe78ayLKX/q3dRj0PZnl7kMj7YpCfY7VCndqoIKEOlIEqNjzAFhHLgHEMJ8f8cM5s4qorgc3TdCqORGVs5vqkeNm977yz2hMxB7iEET4O2jfBUHzzZ68T5h5AtrL5YVBMP0xTgaLskk7/QnoEsfKAgTXo/AaUuXbzM6N0nIjH00Ll0s6P2fWyRVXz05eauZZhBS85GQTD
       gitlab-dev.syn.tools ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCz/gtGxqX+WS6E9/NLYTkRLkM7r7JHU5N7vz2kJjRbjhR91JvP7NaHtuN5aPm5Wv9rtPKSackQ9B78VCkr6GLw=
       gitlab-dev.syn.tools ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKtv4stHQjApa7wkgvgo4dB52qLzI/zN2Us+89cQXXm0
+
+    resource_exclusions:
+      cilium:
+        - apiGroups:
+            - cilium.io
+          kinds:
+            - CiliumIdentity
+          clusters:
+            - "*"
+
     operator:
       migrate: false
       conversion_webhook: false

--- a/component/argocd.jsonnet
+++ b/component/argocd.jsonnet
@@ -246,6 +246,13 @@ local argocd(name) =
         ||| + params.ssh_known_hosts,
       },
       redis: redis,
+      resourceExclusions: std.manifestYamlDoc(
+        std.foldl(
+          function(acc, v) acc + std.flattenArrays([ v ]),
+          std.filter(function(v) v != null, std.objectValues(params.resource_exclusions)),
+          []
+        )
+      ),
       resourceIgnoreDifferences: {
         resourceIdentifiers: [
           {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -19,7 +19,7 @@ default:: ${facts:distribution}
 
 The Kubernetes distribution of the cluster.
 
-=== `resync_time`
+== `resync_time`
 
 [horizontal]
 type:: string
@@ -28,7 +28,7 @@ default:: `3m0s`
 Resync interval.
 Lower values mean quicker sync but higher CPU usage and more Git traffic.
 
-=== `ssh_known_hosts`
+== `ssh_known_hosts`
 
 [horizontal]
 type:: string

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -35,6 +35,48 @@ type:: string
 
 SSH known hosts for Git servers.
 
+
+== `resource_exclusions`
+
+[horizontal]
+type:: dictionary(list|dictionary)
+default::
++
+[source,yaml]
+----
+cilium:
+- apiGroups:
+  - cilium.io
+  kinds:
+  - CiliumIdentity
+  clusters:
+  - "*"
+----
+example::
++
+[source,yaml]
+----
+custom:
+- apiGroups:
+  - custom.io
+  kinds:
+  - ClusterWrecker
+  clusters:
+  - "*"
+backup: null
+----
+
+A dictionary of resource exclusions for the ArgoCD instance.
+Those resources will not be managed by ArgoCD.
+
+The keys are the names of the exclusion groups.
+Keys are not used, they are exclusively for hierarchical structuring.
+
+The values are lists of resource definitions that should be excluded from the ArgoCD instance.
+Those lists get concatenated.
+
+Check https://argo-cd.readthedocs.io/en/stable/user-guide/resource_tracking/#additional-tracking-methods-via-an-annotation[ArgoCD documentation] for more information.
+
 == `network_policies.enabled`
 [horizontal]
 type:: boolean

--- a/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
@@ -139,6 +139,13 @@ spec:
       sshPrivateKeySecret:
         name: argo-ssh-key
         key: sshPrivateKey
+  resourceExclusions: |-
+    - "apiGroups":
+      - "cilium.io"
+      "clusters":
+      - "*"
+      "kinds":
+      - "CiliumIdentity"
   resourceHealthChecks:
     - check: |
         hs = {}

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd.yaml
@@ -136,6 +136,13 @@ spec:
       sshPrivateKeySecret:
         name: argo-ssh-key
         key: sshPrivateKey
+  resourceExclusions: |-
+    - "apiGroups":
+      - "cilium.io"
+      "clusters":
+      - "*"
+      "kinds":
+      - "CiliumIdentity"
   resourceHealthChecks:
     - check: |
         hs = {}

--- a/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
@@ -118,6 +118,19 @@ spec:
       sshPrivateKeySecret:
         name: argo-ssh-key
         key: sshPrivateKey
+  resourceExclusions: |-
+    - "apiGroups":
+      - "cilium.io"
+      "clusters":
+      - "*"
+      "kinds":
+      - "CiliumIdentity"
+    - "apiGroups":
+      - "custom.io"
+      "clusters":
+      - "*"
+      "kinds":
+      - "ClusterWrecker"
   resourceHealthChecks:
     - check: |
         hs = {}

--- a/tests/golden/prometheus/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/prometheus/argocd/argocd/30_argocd/10_argocd.yaml
@@ -139,6 +139,13 @@ spec:
       sshPrivateKeySecret:
         name: argo-ssh-key
         key: sshPrivateKey
+  resourceExclusions: |-
+    - "apiGroups":
+      - "cilium.io"
+      "clusters":
+      - "*"
+      "kinds":
+      - "CiliumIdentity"
   resourceHealthChecks:
     - check: |
         hs = {}

--- a/tests/params.yml
+++ b/tests/params.yml
@@ -86,3 +86,13 @@ parameters:
               destinations:
                 - namespace: other-*
                   server: https://kubernetes.default.svc
+
+    resource_exclusions:
+      custom:
+        - apiGroups:
+            - custom.io
+          kinds:
+            - ClusterWrecker
+          clusters:
+            - "*"
+      nope: null


### PR DESCRIPTION
CiliumIdentity (https://doc.crds.dev/github.com/cilium/cilium/cilium.io/CiliumIdentity/v2) resources are completely  managed by Cilium but copy labels from the resources they refer to. Cilium uses them as a KV store.

This commit stops ArgoCD from purging the resources instantly after creation.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
