### PR TITLE
Fix `Subscription` health check by re-enabling Lua string functions

### DIFF
--- a/component/argocd.jsonnet
+++ b/component/argocd.jsonnet
@@ -278,6 +278,14 @@ local argocd(name) =
           },
         ],
       },
+      extraConfig: {
+        'resource.customizations': std.manifestYamlDoc({
+          'operators.coreos.com/Subscription': {
+            // Required to enable Lua string functions like `string.find`
+            'health.lua.useOpenLibs': true,
+          },
+        }),
+      },
       resourceHealthChecks: [
         {
           group: 'pkg.crossplane.io',

--- a/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
@@ -22,6 +22,10 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
+  extraConfig:
+    resource.customizations: |-
+      "operators.coreos.com/Subscription":
+        "health.lua.useOpenLibs": true
   image: quay.io/argoproj/argocd
   initialRepositories: '- url: ssh://git@git.example.com/org/repo.git'
   initialSSHKnownHosts:

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd.yaml
@@ -22,6 +22,10 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
+  extraConfig:
+    resource.customizations: |-
+      "operators.coreos.com/Subscription":
+        "health.lua.useOpenLibs": true
   image: quay.io/argoproj/argocd
   initialRepositories: '- url: ssh://git@git.example.com/org/repo.git'
   initialSSHKnownHosts:

--- a/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
@@ -16,6 +16,10 @@ spec:
     processors:
       operation: 10
       status: 20
+  extraConfig:
+    resource.customizations: |-
+      "operators.coreos.com/Subscription":
+        "health.lua.useOpenLibs": true
   image: quay.io/argoproj/argocd
   initialRepositories: '- url: ssh://git@git.example.com/org/repo.git'
   initialSSHKnownHosts:

--- a/tests/golden/prometheus/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/prometheus/argocd/argocd/30_argocd/10_argocd.yaml
@@ -22,6 +22,10 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
+  extraConfig:
+    resource.customizations: |-
+      "operators.coreos.com/Subscription":
+        "health.lua.useOpenLibs": true
   image: quay.io/argoproj/argocd
   initialRepositories: '- url: ssh://git@git.example.com/org/repo.git'
   initialSSHKnownHosts:


### PR DESCRIPTION
The `health.lua.useOpenLibs` parameter got lost when migrating switching to ArgoCD `v0.8.0`.

https://github.com/projectsyn/component-argocd/commit/52ca09e8b2a2f4658a9676428dfb8824e9bab5cd

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
