### PR TITLE
Deploy cronjob which periodically refreshes the `syn-argocd-tls` secret

### DIFF
--- a/component/argocd.jsonnet
+++ b/component/argocd.jsonnet
@@ -421,7 +421,10 @@ local tls_role = kube.Role('syn-argocd-tls-refresher') {
     apiGroups: [ '' ],
     resources: [ 'secrets' ],
     verbs: [ 'delete' ],
-    resourceNames: [ 'syn-argocd-tls' ],
+    resourceNames: [
+      'syn-argocd-tls',
+      'syn-argocd-ca',
+    ],
   } ],
 };
 local tls_rolebinding = kube.RoleBinding('syn-argocd-tls-refresher') {
@@ -453,6 +456,7 @@ local tls_cronjob =
                     'delete',
                     'secret',
                     'syn-argocd-tls',
+                    'syn-argocd-ca',
                   ],
                   env_: {
                     HOME: homedir,

--- a/tests/golden/defaults/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -20,6 +20,7 @@ rules:
       - ''
     resourceNames:
       - syn-argocd-tls
+      - syn-argocd-ca
     resources:
       - secrets
     verbs:
@@ -69,6 +70,7 @@ spec:
                 - delete
                 - secret
                 - syn-argocd-tls
+                - syn-argocd-ca
               env:
                 - name: HOME
                   value: /home/refresh

--- a/tests/golden/defaults/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - syn-argocd-tls
+    resources:
+      - secrets
+    verbs:
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: syn-argocd-tls-refresher
+subjects:
+  - kind: ServiceAccount
+    name: syn-argocd-tls-refresher
+    namespace: syn
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: syn-argocd-tls-refresher
+        spec:
+          containers:
+            - args: []
+              command:
+                - kubectl
+                - delete
+                - secret
+                - syn-argocd-tls
+              env:
+                - name: HOME
+                  value: /home/refresh
+              image: docker.io/bitnami/kubectl
+              imagePullPolicy: IfNotPresent
+              name: refresh
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /home/refresh
+                  name: home
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: syn-argocd-tls-refresher
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: home
+  schedule: 0 9 1 */4 *
+  successfulJobsHistoryLimit: 10

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -20,6 +20,7 @@ rules:
       - ''
     resourceNames:
       - syn-argocd-tls
+      - syn-argocd-ca
     resources:
       - secrets
     verbs:
@@ -69,6 +70,7 @@ spec:
                 - delete
                 - secret
                 - syn-argocd-tls
+                - syn-argocd-ca
               env:
                 - name: HOME
                   value: /home/refresh

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - syn-argocd-tls
+    resources:
+      - secrets
+    verbs:
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: syn-argocd-tls-refresher
+subjects:
+  - kind: ServiceAccount
+    name: syn-argocd-tls-refresher
+    namespace: syn
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: syn-argocd-tls-refresher
+        spec:
+          containers:
+            - args: []
+              command:
+                - kubectl
+                - delete
+                - secret
+                - syn-argocd-tls
+              env:
+                - name: HOME
+                  value: /home/refresh
+              image: docker.io/bitnami/kubectl
+              imagePullPolicy: IfNotPresent
+              name: refresh
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /home/refresh
+                  name: home
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: syn-argocd-tls-refresher
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: home
+  schedule: 0 9 1 */4 *
+  successfulJobsHistoryLimit: 10

--- a/tests/golden/params/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -20,6 +20,7 @@ rules:
       - ''
     resourceNames:
       - syn-argocd-tls
+      - syn-argocd-ca
     resources:
       - secrets
     verbs:
@@ -69,6 +70,7 @@ spec:
                 - delete
                 - secret
                 - syn-argocd-tls
+                - syn-argocd-ca
               env:
                 - name: HOME
                   value: /home/refresh

--- a/tests/golden/params/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - syn-argocd-tls
+    resources:
+      - secrets
+    verbs:
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: syn-argocd-tls-refresher
+subjects:
+  - kind: ServiceAccount
+    name: syn-argocd-tls-refresher
+    namespace: syn
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: syn-argocd-tls-refresher
+        spec:
+          containers:
+            - args: []
+              command:
+                - kubectl
+                - delete
+                - secret
+                - syn-argocd-tls
+              env:
+                - name: HOME
+                  value: /home/refresh
+              image: docker.io/bitnami/kubectl
+              imagePullPolicy: IfNotPresent
+              name: refresh
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /home/refresh
+                  name: home
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: syn-argocd-tls-refresher
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: home
+  schedule: 0 9 1 */4 *
+  successfulJobsHistoryLimit: 10

--- a/tests/golden/prometheus/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/prometheus/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -20,6 +20,7 @@ rules:
       - ''
     resourceNames:
       - syn-argocd-tls
+      - syn-argocd-ca
     resources:
       - secrets
     verbs:
@@ -69,6 +70,7 @@ spec:
                 - delete
                 - secret
                 - syn-argocd-tls
+                - syn-argocd-ca
               env:
                 - name: HOME
                   value: /home/refresh

--- a/tests/golden/prometheus/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/prometheus/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - syn-argocd-tls
+    resources:
+      - secrets
+    verbs:
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: syn-argocd-tls-refresher
+subjects:
+  - kind: ServiceAccount
+    name: syn-argocd-tls-refresher
+    namespace: syn
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: syn-argocd-tls-refresher
+  name: syn-argocd-tls-refresher
+  namespace: syn
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: syn-argocd-tls-refresher
+        spec:
+          containers:
+            - args: []
+              command:
+                - kubectl
+                - delete
+                - secret
+                - syn-argocd-tls
+              env:
+                - name: HOME
+                  value: /home/refresh
+              image: docker.io/bitnami/kubectl
+              imagePullPolicy: IfNotPresent
+              name: refresh
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /home/refresh
+                  name: home
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: syn-argocd-tls-refresher
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: home
+  schedule: 0 9 1 */4 *
+  successfulJobsHistoryLimit: 10


### PR DESCRIPTION
Unfortunately, the argocd-operator currently doesn't refresh the certificate stored in secret `syn-argocd-tls` even when the certificate is expired or expires soon (cf. https://github.com/argoproj-labs/argocd-operator/blob/17e355a31b8e2bb7c2ad9a349818e2940bf22fd8/controllers/argocd/secret.go#L224-L257).

To circumvent the certificate expiring (the lifetime is hardcoded to 1 year), we deploy a CronJob which deletes the `syn-argocd-tls` secret every 4 months to force the operator to recreate it with a new certificate.



## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
