### PR TITLE
Disable pruning for automated sync of root app

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -27,6 +27,11 @@ local root_app = argocd.App('root', params.namespace, secrets=false) {
     source+: {
       path: 'manifests/apps/',
     },
+    syncPolicy+: {
+      automated+: {
+        prune: false,
+      },
+    },
   },
 };
 

--- a/tests/golden/defaults/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/defaults/argocd/apps/01_rootapp.yaml
@@ -16,5 +16,5 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: true

--- a/tests/golden/https-catalog/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/https-catalog/argocd/apps/01_rootapp.yaml
@@ -16,5 +16,5 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: true

--- a/tests/golden/openshift/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/openshift/argocd/apps/01_rootapp.yaml
@@ -16,5 +16,5 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: true

--- a/tests/golden/params/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/params/argocd/apps/01_rootapp.yaml
@@ -16,5 +16,5 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: true

--- a/tests/golden/prometheus/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/prometheus/argocd/apps/01_rootapp.yaml
@@ -16,5 +16,5 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: true


### PR DESCRIPTION
This ensures that we'll be able to roll out support for multiple root apps without having to disable auto-sync for the default root app before the roll out, since we already have some configuration that will reassign existing component instances to another root app.

Later, we'll want to keep this setting, so we can move component instances between different root apps without having to manually disable auto-sync for the root apps on all clusters that use the component that's being moved.

Extracted from #216 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
