### PR TITLE
Replace `gcr.io` `kube-rbac-proxy` image

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -61,9 +61,9 @@ parameters:
         repository: argoprojlabs/argocd-operator
         tag: v0.12.2
       kube_rbac_proxy:
-        registry: gcr.io
-        repository: kubebuilder/kube-rbac-proxy
-        tag: v0.16.0
+        registry: quay.io
+        repository: brancz/kube-rbac-proxy
+        tag: v0.18.2
 
     instances: {}
 

--- a/component/operator.jsonnet
+++ b/component/operator.jsonnet
@@ -75,6 +75,10 @@ com.Kustomization(
       newTag: rbac.tag,
       newName: '%(registry)s/%(repository)s' % rbac,
     },
+    'quay.io/brancz/kube-rbac-proxy': {
+      newTag: rbac.tag,
+      newName: '%(registry)s/%(repository)s' % rbac,
+    },
   },
   kustomize_input,
 )

--- a/tests/golden/defaults/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
+++ b/tests/golden/defaults/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
@@ -23,7 +23,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.18.2
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/tests/golden/https-catalog/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
+++ b/tests/golden/https-catalog/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
@@ -23,7 +23,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.18.2
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/tests/golden/openshift/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
+++ b/tests/golden/openshift/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
@@ -23,7 +23,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.18.2
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/tests/golden/params/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
+++ b/tests/golden/params/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
@@ -23,7 +23,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: mymirror.io/kubebuilder/kube-rbac-proxy:v1.1.1
+          image: mymirror.io/brancz/kube-rbac-proxy:v1.1.1
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/tests/golden/prometheus/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
+++ b/tests/golden/prometheus/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
@@ -23,7 +23,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.18.2
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/tests/golden/syn-teams/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
+++ b/tests/golden/syn-teams/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
@@ -23,7 +23,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.18.2
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443


### PR DESCRIPTION
`gcr.io` is deprecated and will be removed https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
