### PR TITLE
Fix multi-team-awareness check in `ArgoApp()` helper

### DIFF
--- a/lib/argocd.libjsonnet
+++ b/lib/argocd.libjsonnet
@@ -17,18 +17,20 @@ local params = inv.parameters.argocd;
  * \arg `namespace` (required) the namespace where to deploy the app
  * \arg `project` the Argo CD project for this app. Default: 'syn'
  * \arg `secrets` if the Kapitan plugin should be used to reveal secrets from Vault. Default: 'true'
+ * \arg `base` the unaliased name of the component. Required for multi-team and multi-instance aware components. Default: null
  *
  * \returns an Argo CD Application object
  *
  * See the documentation https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#applications
  */
-local ArgoApp(component, namespace, project=null, secrets=true) =
+local ArgoApp(component, namespace, project=null, secrets=true, base=null) =
+  local base_component = if base != null then base else component;
   local team = syn_teams.teamForApplication(component);
   local proj =
     if project != null then (
       std.trace('Parameter `project` for `ArgoApp` is deprecated and will be removed in a future version. Set to `%s`' % project, project)
     ) else if team != syn_teams.owner then (
-      if syn_teams.isMultiTenantAware(component) then
+      if syn_teams.isMultiTenantAware(base_component) then
         team
       else
         error


### PR DESCRIPTION
NOTE: We'll need to update all multi-team and multi-instance aware components to pass `base=<component-name>` when calling this function.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
