### PR TITLE
Deploy configmap containing the cluster's Project Syn ID and tenant ID

### DIFF
--- a/class/argocd.yml
+++ b/class/argocd.yml
@@ -9,6 +9,10 @@ parameters:
         input_type: jsonnet
         input_paths:
           - argocd/component/namespace.jsonnet
+      - output_path: argocd/02_cluster_info/
+        input_type: jsonnet
+        input_paths:
+          - argocd/component/cluster-info.jsonnet
       - output_path: argocd/20_rbac/
         input_type: jsonnet
         input_paths:

--- a/component/cluster-info.jsonnet
+++ b/component/cluster-info.jsonnet
@@ -1,0 +1,55 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.argocd;
+
+local cluster_info_configmap =
+  kube.ConfigMap('cluster-info') {
+    metadata+: {
+      namespace: params.namespace,
+      annotations+: {
+        'syn.tools/description':
+          'The cluster-info config map contains a selection of Project Syn metadata associated with the cluster. All authenticated users can access this configmap.',
+      },
+    },
+    data: {
+      cluster_id: inv.parameters.cluster.name,
+      tenant_id: inv.parameters.cluster.tenant,
+    },
+  };
+
+local cluster_info_configmap_role = kube.Role('cluster-info-access') {
+  metadata+: {
+    namespace: params.namespace,
+  },
+  rules: [
+    {
+      apiGroups: [ '' ],
+      resources: [ 'configmaps' ],
+      resourceNames: [ cluster_info_configmap.metadata.name ],
+      verbs: [ 'get' ],
+    },
+  ],
+};
+
+local cluster_info_configmap_rolebinding = kube.RoleBinding('cluster-info-access') {
+  metadata+: {
+    namespace: params.namespace,
+  },
+  subjects: [
+    {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'Group',
+      name: 'system:authenticated',
+    },
+  ],
+  roleRef_: cluster_info_configmap_role,
+};
+
+{
+  configmap: cluster_info_configmap,
+  rbac: [
+    cluster_info_configmap_role,
+    cluster_info_configmap_rolebinding,
+  ],
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,6 +10,13 @@ default:: `syn`
 
 The namespace in which to deploy this component.
 
+[TIP]
+====
+The component deploys a configmap called `cluster-info` in this namespace.
+The configmap contains some Project Syn metadata associated with the cluster.
+All authenticated users (group `system:authenticated`) can read this configmap.
+====
+
 == `distribution`
 
 [horizontal]

--- a/tests/golden/defaults/argocd/argocd/02_cluster_info/configmap.yaml
+++ b/tests/golden/defaults/argocd/argocd/02_cluster_info/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  cluster_id: c-green-test-1234
+  tenant_id: t-silent-test-1234
+kind: ConfigMap
+metadata:
+  annotations:
+    syn.tools/description: The cluster-info config map contains a selection of Project
+      Syn metadata associated with the cluster. All authenticated users can access
+      this configmap.
+  labels:
+    name: cluster-info
+  name: cluster-info
+  namespace: syn

--- a/tests/golden/defaults/argocd/argocd/02_cluster_info/rbac.yaml
+++ b/tests/golden/defaults/argocd/argocd/02_cluster_info/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-info-access
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/tests/golden/https-catalog/argocd/argocd/02_cluster_info/configmap.yaml
+++ b/tests/golden/https-catalog/argocd/argocd/02_cluster_info/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  cluster_id: c-green-test-1234
+  tenant_id: t-silent-test-1234
+kind: ConfigMap
+metadata:
+  annotations:
+    syn.tools/description: The cluster-info config map contains a selection of Project
+      Syn metadata associated with the cluster. All authenticated users can access
+      this configmap.
+  labels:
+    name: cluster-info
+  name: cluster-info
+  namespace: syn

--- a/tests/golden/https-catalog/argocd/argocd/02_cluster_info/rbac.yaml
+++ b/tests/golden/https-catalog/argocd/argocd/02_cluster_info/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-info-access
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/tests/golden/openshift/argocd/argocd/02_cluster_info/configmap.yaml
+++ b/tests/golden/openshift/argocd/argocd/02_cluster_info/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  cluster_id: c-green-test-1234
+  tenant_id: t-silent-test-1234
+kind: ConfigMap
+metadata:
+  annotations:
+    syn.tools/description: The cluster-info config map contains a selection of Project
+      Syn metadata associated with the cluster. All authenticated users can access
+      this configmap.
+  labels:
+    name: cluster-info
+  name: cluster-info
+  namespace: syn

--- a/tests/golden/openshift/argocd/argocd/02_cluster_info/rbac.yaml
+++ b/tests/golden/openshift/argocd/argocd/02_cluster_info/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-info-access
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/tests/golden/params/argocd/argocd/02_cluster_info/configmap.yaml
+++ b/tests/golden/params/argocd/argocd/02_cluster_info/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  cluster_id: c-green-test-1234
+  tenant_id: t-silent-test-1234
+kind: ConfigMap
+metadata:
+  annotations:
+    syn.tools/description: The cluster-info config map contains a selection of Project
+      Syn metadata associated with the cluster. All authenticated users can access
+      this configmap.
+  labels:
+    name: cluster-info
+  name: cluster-info
+  namespace: syn

--- a/tests/golden/params/argocd/argocd/02_cluster_info/rbac.yaml
+++ b/tests/golden/params/argocd/argocd/02_cluster_info/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-info-access
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/tests/golden/prometheus/argocd/argocd/02_cluster_info/configmap.yaml
+++ b/tests/golden/prometheus/argocd/argocd/02_cluster_info/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  cluster_id: c-green-test-1234
+  tenant_id: t-silent-test-1234
+kind: ConfigMap
+metadata:
+  annotations:
+    syn.tools/description: The cluster-info config map contains a selection of Project
+      Syn metadata associated with the cluster. All authenticated users can access
+      this configmap.
+  labels:
+    name: cluster-info
+  name: cluster-info
+  namespace: syn

--- a/tests/golden/prometheus/argocd/argocd/02_cluster_info/rbac.yaml
+++ b/tests/golden/prometheus/argocd/argocd/02_cluster_info/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-info-access
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/tests/golden/syn-teams/argocd/argocd/02_cluster_info/configmap.yaml
+++ b/tests/golden/syn-teams/argocd/argocd/02_cluster_info/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  cluster_id: c-green-test-1234
+  tenant_id: t-silent-test-1234
+kind: ConfigMap
+metadata:
+  annotations:
+    syn.tools/description: The cluster-info config map contains a selection of Project
+      Syn metadata associated with the cluster. All authenticated users can access
+      this configmap.
+  labels:
+    name: cluster-info
+  name: cluster-info
+  namespace: syn

--- a/tests/golden/syn-teams/argocd/argocd/02_cluster_info/rbac.yaml
+++ b/tests/golden/syn-teams/argocd/argocd/02_cluster_info/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - cluster-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-info-access
+  name: cluster-info-access
+  namespace: syn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-info-access
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated


### PR DESCRIPTION
This PR introduces code which deploys a configmap `cluster-info` in the Project Syn ArgoCD namespace (default `syn`). The configmap can be read by all authenticated users (group `system:authenticated`).

This will provide an easy way for any customer users to extract the cluster ID (e.g. for configuring network policies with Cilium cluster mesh, cf. https://github.com/appuio/managed-openshift-docs/pull/12#discussion_r2001502471).

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
