### PR TITLE
Implement support for deploying custom ArgoCD cluster roles

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -121,6 +121,8 @@ parameters:
       manifests_version: ${argocd:images:argocd_operator:tag}
       cluster_scope_namespaces:
         - "${argocd:namespace}"
+      controller_cluster_role_selectors: {}
+      server_cluster_role_selectors: {}
       env: {}
       kustomization_url: https://github.com/argoproj-labs/argocd-operator//config/default/
       kustomize_input:

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -23,9 +23,15 @@ local render_image(imagename, include_tag=false) =
   else
     image;
 
+local custom_cr_name(component) =
+  assert
+    std.member([ 'server', 'application-controller' ], component) :
+    'Custom clusterrole only supported for server and application-controller';
+  'syn:argocd-%s:custom' % component;
 
 {
   render_image: render_image,
   evaluate_log_level: evaluate_log_level,
   evaluate_log_format: evaluate_log_format,
+  custom_cluster_role_name: custom_cr_name,
 }

--- a/component/operator.jsonnet
+++ b/component/operator.jsonnet
@@ -1,3 +1,4 @@
+local common = import 'common.libsonnet';
 local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 
@@ -7,8 +8,36 @@ local params = inv.parameters.argocd.operator;
 local image = params.images.argocd_operator;
 local rbac = params.images.kube_rbac_proxy;
 
+local managed_custom_controller_cr =
+  std.length(std.prune(std.objectValues(params.controller_cluster_role_selectors))) > 0;
+local managed_custom_server_cr =
+  std.length(std.prune(std.objectValues(params.server_cluster_role_selectors))) > 0;
+
 local skip(var) =
-  var == 'ARGOCD_CLUSTER_CONFIG_NAMESPACES';
+  (var == 'ARGOCD_CLUSTER_CONFIG_NAMESPACES') ||
+  (managed_custom_controller_cr && var == 'CONTROLLER_CLUSTER_ROLE') ||
+  (managed_custom_server_cr && var == 'SERVER_CLUSTER_ROLE');
+
+local managed_clusterrole_patches =
+  local controller_patch =
+    if managed_custom_controller_cr then {
+      op: 'add',
+      path: '/spec/template/spec/containers/1/env/-',
+      value: {
+        name: 'CONTROLLER_CLUSTER_ROLE',
+        value: common.custom_cluster_role_name('application-controller'),
+      },
+    };
+  local server_patch =
+    if managed_custom_server_cr then {
+      op: 'add',
+      path: '/spec/template/spec/containers/1/env/-',
+      value: {
+        name: 'SERVER_CLUSTER_ROLE',
+        value: common.custom_cluster_role_name('server'),
+      },
+    };
+  std.prune([ controller_patch, server_patch ]);
 
 local kustomize_patch_scopens = if std.length(params.cluster_scope_namespaces) > 0 then {
   patches+: [
@@ -33,7 +62,7 @@ local kustomize_patch_scopens = if std.length(params.cluster_scope_namespaces) >
         }
         for envvar in std.objectFields(params.env)
         if !skip(envvar)
-      ]),
+      ] + managed_clusterrole_patches),
       target: {
         kind: 'Deployment',
         name: 'argocd-operator-controller-manager',

--- a/component/rbac.jsonnet
+++ b/component/rbac.jsonnet
@@ -1,3 +1,4 @@
+local common = import 'common.libsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
@@ -54,7 +55,207 @@ local aggregated_rbac = [
   },
 ];
 
+local internalControllerAggregationLabel = {
+  'rbac.argocd.syn.tools/aggregate-to-controller': 'true',
+};
+
+local custom_controller_cr =
+  kube.ClusterRole(common.custom_cluster_role_name('application-controller')) {
+    metadata+: {
+      annotations+: {
+        'syn.tools/description': |||
+          Custom ClusterRole which is used to give the ArgoCD application
+          controller access to managed namespaces. Intended to be configured
+          as `CONTROLLER_CLUSTER_ROLE` on the operator.
+
+          This ClusterRole aggregates the rules of all clusterroles which
+          match one of the selectors in `aggregationRule.clusterRoleSelectors`.
+        |||,
+      },
+    },
+    rules:: [],
+    aggregationRule: {
+      clusterRoleSelectors: [
+        { matchLabels: internalControllerAggregationLabel },
+      ] + [
+        sel
+        for sel in
+          std.objectValues(params.operator.controller_cluster_role_selectors)
+        if sel != null
+      ],
+    },
+  };
+
+local controller_required_cr =
+  kube.ClusterRole('syn:argocd-application-controller:required') {
+    metadata+: {
+      labels+: internalControllerAggregationLabel,
+      annotations+: {
+        'syn.tools/description': |||
+          Custom ClusterRole which is used to aggregate a basic set of
+          permissions to the custom ArgoCD application controller clusterrole
+          `%s`.
+
+          This rule is required to allow the application controller to run
+          normally (emitting events, updating application status, etc)
+        ||| % common.custom_cluster_role_name('application-controller'),
+      },
+    },
+    rules: [
+      {
+        apiGroups: [ '' ],
+        resources: [ 'secrets' ],
+        verbs: [
+          'get',
+          'list',
+          'watch',
+        ],
+      },
+      {
+        apiGroups: [ 'argoproj.io' ],
+        resources: [
+          'applications',
+          'applicationsets',
+          'appprojects',
+        ],
+        verbs: [
+          'create',
+          'get',
+          'list',
+          'watch',
+          'update',
+          'delete',
+          'patch',
+        ],
+      },
+      {
+        apiGroups: [ '' ],
+        resources: [ 'events' ],
+        verbs: [ 'create', 'list' ],
+      },
+      {
+        apiGroups: [ 'batch' ],
+        resources: [
+          'jobs',
+        ],
+        verbs: [
+          'create',
+          'get',
+          'list',
+          'watch',
+          'update',
+          'delete',
+          'patch',
+        ],
+      },
+    ],
+  };
+
+local internalServerAggregationLabel = {
+  'rbac.argocd.syn.tools/aggregate-to-server': 'true',
+};
+
+local custom_server_cr =
+  kube.ClusterRole(common.custom_cluster_role_name('server')) {
+    metadata+: {
+      annotations+: {
+        'syn.tools/description': |||
+          Custom ClusterRole which is used to give the ArgoCD server access to
+          managed namespaces. Intended to be configured as
+          `SERVER_CLUSTER_ROLE` on the operator.
+
+          This ClusterRole aggregates the rules of all clusterroles which
+          match one of the selectors in `aggregationRule.clusterRoleSelectors`.
+        |||,
+      },
+    },
+    rules:: [],
+    aggregationRule: {
+      clusterRoleSelectors: [
+        { matchLabels: internalServerAggregationLabel },
+      ] + [
+        sel
+        for sel in
+          std.objectValues(params.operator.server_cluster_role_selectors)
+        if sel != null
+      ],
+    },
+  };
+
+local server_required_cr =
+  kube.ClusterRole('syn:argocd-server:required') {
+    metadata+: {
+      labels+: internalServerAggregationLabel,
+      annotations+: {
+        'syn.tools/description': |||
+          Custom ClusterRole which is used to aggregate some required rules to
+          the ArgoCD server custom clusterrole `%s`.
+
+          The rules in this role are necessary to allow the ArgoCD server to
+          fetch the information it needs to display its web interface and to
+          perform operations on its managed ArgoCD apps.
+        ||| % common.custom_cluster_role_name('server'),
+      },
+    },
+    rules: [
+      {
+        apiGroups: [ '*' ],
+        resources: [ '*' ],
+        verbs: [ 'get' ],
+      },
+      {
+        apiGroups: [ '' ],
+        resources: [ 'secrets', 'configmaps' ],
+        verbs: [
+          'create',
+          'get',
+          'list',
+          'watch',
+          'update',
+          'patch',
+          'delete',
+        ],
+      },
+      {
+        apiGroups: [ 'argoproj.io' ],
+        resources: [
+          'applications',
+          'applicationsets',
+          'appprojects',
+        ],
+        verbs: [
+          'create',
+          'get',
+          'list',
+          'watch',
+          'update',
+          'delete',
+          'patch',
+        ],
+      },
+      {
+        apiGroups: [ '' ],
+        resources: [ 'events' ],
+        verbs: [ 'create', 'list' ],
+      },
+      {
+        apiGroups: [ 'batch' ],
+        resources: [
+          'jobs',
+          'cronjobs',
+          'cronjobs/finalizers',
+        ],
+        verbs: [ 'create', 'update' ],
+      },
+    ],
+  };
+
 {
   ['%s-%s' % [ obj.metadata.name, std.asciiLower(obj.kind) ]]: obj
   for obj in aggregated_rbac
+} + {
+  [if std.length(custom_controller_cr.aggregationRule.clusterRoleSelectors) > 1
+  then 'custom_controller_clusterrole']: [ custom_controller_cr, controller_required_cr ],
+  [if std.length(custom_server_cr.aggregationRule.clusterRoleSelectors) > 1
+  then 'custom_server_clusterroles']: [ custom_server_cr, server_required_cr ],
 }

--- a/component/rbac.jsonnet
+++ b/component/rbac.jsonnet
@@ -142,7 +142,7 @@ local controller_required_cr =
       {
         apiGroups: [ '' ],
         resources: [ 'events' ],
-        verbs: [ 'create', 'list' ],
+        verbs: [ 'create', 'list', 'patch' ],
       },
       // Required for running hook jobs
       {
@@ -258,7 +258,7 @@ local server_required_cr =
       {
         apiGroups: [ '' ],
         resources: [ 'events' ],
-        verbs: [ 'create', 'list' ],
+        verbs: [ 'create', 'list', 'patch' ],
       },
       // NOTE(sg): I assume this is also required for hook jobs, but haven't
       // found solid evidence for or against that assumption.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -317,6 +317,82 @@ default:: `["${argocd:namespace}"]`
 
 List of namespaces in which argocd is allowed to be installed at the cluster scope.
 
+=== `operator.controller_cluster_role_selectors`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+The component has optional support to configure the operator's https://argocd-operator.readthedocs.io/en/latest/usage/custom_roles/[custom roles] feature.
+When this parameter contains one or more entries, the component deploys a cluster role which uses the value of each parameter entry as an entry for `aggregationRule.clusterRoleSelectors`.
+The cluster role is named `syn:argocd-application-controller:custom`.
+Additionally, the component configures environment variable `CONTROLLER_CUSTOM_ROLE=syn:argocd-application-controller:custom` on the operator container when the parameter isn't empty.
+
+When the aggregating cluster role is deployed, the component also deploys a cluster role called `syn:argocd-application-controller:required` which is aggregated to the `syn:argocd-application-controller:custom` role.
+
+The `syn:argocd-application-controller:required` role grants the ArgoCD application controller a number of permissions that are required for it to work.
+See the definition of the role in https://github.com/projectsyn/component-argocd/blob/master/component/rbac.jsonnet[component/rbac.jsonnet] for the rules that are required.
+
+[TIP]
+====
+We recommend setting `resource.respectRBAC=strict` via `spec.extraConfig` on namespace-scoped ArgoCD instances if you want to use custom roles.
+
+If you don't set `resource.respectRBAC`, you'll need to create a cluster role which grants the application controller read access to all resources in the cluster in order to ensure that the application controller can create the K8s API cache.
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-application-controller-api-cache
+  labels:
+    syn.tools/aggregate-to-argocd-application-controller: "true" <1>
+rules:
+- apiGroups: ['*']
+  resources: ['*']
+  verbs: ['get', 'list', 'watch']
+----
+<1> The example assumes that you've configured `syn.tools/aggregate-to-argocd-application-controller="true"` as the label selector for the application controller aggregating cluster role.
+====
+
+[IMPORTANT]
+====
+ArgoCD may fail to update the argocd-operator deployment if you remove this config parameter after having used it.
+If you get an error like the one shown below, you need to edit the argocd-operator deployment by hand to remove the `CONTROLLER_CLUSTER_ROLE` environment variable after you remove this config parameter.
+
+[source]
+----
+Failed to compare desired state to live state: failed to calculate diff: error calculating server side diff: serverSideDiff error: error removing non config mutations for resource Deployment/syn-argocd-operator-controller-manager: error reverting webhook removed fields in predicted live resource: .spec.template.spec.containers: element 0: associative list with keys has an element that omits key field "name" (and doesn't have default value)
+----
+====
+
+=== `operator.server_cluster_role_selectors`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+The component has optional support to configure the operator's https://argocd-operator.readthedocs.io/en/latest/usage/custom_roles/[custom roles] feature.
+When this parameter contains one or more entries, the component deploys a cluster role which uses the value of each parameter entry as an entry for `aggregationRule.clusterRoleSelectors`.
+The cluster role is named `syn:argocd-server:custom`.
+Additionally, the component configures environment variable `SERVER_CUSTOM_ROLE=syn:argocd-server:custom` on the operator container when the parameter isn't empty.
+
+When the aggregating cluster role is deployed, the component also deploys a cluster role called `syn:argocd-server:required` which is aggregated to the `syn:argocd-server:custom` role.
+
+The `syn:argocd-server:required` role grants the ArgoCD server a number of permissions that are required for it to work.
+See the definition of the role in https://github.com/projectsyn/component-argocd/blob/master/component/rbac.jsonnet[component/rbac.jsonnet] for the rules that are required.
+
+[IMPORTANT]
+====
+ArgoCD may fail to update the argocd-operator deployment if you remove this config parameter after having used it.
+If you get an error like the one shown below, you need to edit the argocd-operator deployment by hand to remove the `SERVER_CLUSTER_ROLE` environment variable after you remove this config parameter.
+
+[source]
+----
+Failed to compare desired state to live state: failed to calculate diff: error calculating server side diff: serverSideDiff error: error removing non config mutations for resource Deployment/syn-argocd-operator-controller-manager: error reverting webhook removed fields in predicted live resource: .spec.template.spec.containers: element 0: associative list with keys has an element that omits key field "name" (and doesn't have default value)
+----
+====
+
 === `operator.env`
 
 [horizontal]
@@ -330,6 +406,16 @@ Entries in this dictionary are configured as environment variables for the argoc
 The environment variable `ARGOCD_CLUSTER_CONFIG_NAMESPACES` can't be set through this parameter.
 
 This variable is configured through component parameter `operator.cluster_scope_namespaces`.
+====
+
+[NOTE]
+====
+When parameter `operator.controller_cluster_role_match_labels` isn't empty, setting `CONTROLLER_CUSTOM_ROLE` through this parameter has no effect.
+====
+
+[NOTE]
+====
+When parameter `operator.server_cluster_role_match_labels` isn't empty, setting `SERVER_CUSTOM_ROLE` through this parameter has no effect.
 ====
 
 [IMPORTANT]

--- a/tests/golden/params/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
+++ b/tests/golden/params/argocd/argocd/10_operator/apps_v1_deployment_syn-argocd-operator-controller-manager.yaml
@@ -51,6 +51,10 @@ spec:
               value: syn
             - name: FOO
               value: bar
+            - name: CONTROLLER_CLUSTER_ROLE
+              value: syn:argocd-application-controller:custom
+            - name: SERVER_CLUSTER_ROLE
+              value: syn:argocd-server:custom
           image: quay.io/argoprojlabs/argocd-operator:v0.12.2
           livenessProbe:
             httpGet:

--- a/tests/golden/params/argocd/argocd/20_rbac/custom_controller_clusterrole.yaml
+++ b/tests/golden/params/argocd/argocd/20_rbac/custom_controller_clusterrole.yaml
@@ -66,6 +66,7 @@ rules:
     verbs:
       - create
       - list
+      - patch
   - apiGroups:
       - batch
     resources:

--- a/tests/golden/params/argocd/argocd/20_rbac/custom_controller_clusterrole.yaml
+++ b/tests/golden/params/argocd/argocd/20_rbac/custom_controller_clusterrole.yaml
@@ -1,0 +1,80 @@
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.argocd.syn.tools/aggregate-to-controller: 'true'
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    - matchLabels:
+        syn.tools/aggregate-to-argocd-application-controller: 'true'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    syn.tools/description: |
+      Custom ClusterRole which is used to give the ArgoCD application
+      controller access to managed namespaces. Intended to be configured
+      as `CONTROLLER_CLUSTER_ROLE` on the operator.
+
+      This ClusterRole aggregates the rules of all clusterroles which
+      match one of the selectors in `aggregationRule.clusterRoleSelectors`.
+  labels:
+    name: syn-argocd-application-controller-custom
+  name: syn:argocd-application-controller:custom
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    syn.tools/description: |
+      Custom ClusterRole which is used to aggregate a basic set of
+      permissions to the custom ArgoCD application controller clusterrole
+      `syn:argocd-application-controller:custom`.
+
+      This rule is required to allow the application controller to run
+      normally (emitting events, updating application status, etc)
+  labels:
+    name: syn-argocd-application-controller-required
+    rbac.argocd.syn.tools/aggregate-to-controller: 'true'
+  name: syn:argocd-application-controller:required
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+      - appprojects
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - list
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
+      - patch

--- a/tests/golden/params/argocd/argocd/20_rbac/custom_server_clusterroles.yaml
+++ b/tests/golden/params/argocd/argocd/20_rbac/custom_server_clusterroles.yaml
@@ -75,6 +75,7 @@ rules:
     verbs:
       - create
       - list
+      - patch
   - apiGroups:
       - batch
     resources:

--- a/tests/golden/params/argocd/argocd/20_rbac/custom_server_clusterroles.yaml
+++ b/tests/golden/params/argocd/argocd/20_rbac/custom_server_clusterroles.yaml
@@ -1,0 +1,86 @@
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.argocd.syn.tools/aggregate-to-server: 'true'
+    - matchLabels:
+        syn.tools/aggregate-to-argocd-server: 'true'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    syn.tools/description: |
+      Custom ClusterRole which is used to give the ArgoCD server access to
+      managed namespaces. Intended to be configured as
+      `SERVER_CLUSTER_ROLE` on the operator.
+
+      This ClusterRole aggregates the rules of all clusterroles which
+      match one of the selectors in `aggregationRule.clusterRoleSelectors`.
+  labels:
+    name: syn-argocd-server-custom
+  name: syn:argocd-server:custom
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    syn.tools/description: |
+      Custom ClusterRole which is used to aggregate some required rules to
+      the ArgoCD server custom clusterrole `syn:argocd-server:custom`.
+
+      The rules in this role are necessary to allow the ArgoCD server to
+      fetch the information it needs to display its web interface and to
+      perform operations on its managed ArgoCD apps.
+  labels:
+    name: syn-argocd-server-required
+    rbac.argocd.syn.tools/aggregate-to-server: 'true'
+  name: syn:argocd-server:required
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - applicationsets
+      - appprojects
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - list
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+      - cronjobs/finalizers
+    verbs:
+      - create
+      - update

--- a/tests/params.yml
+++ b/tests/params.yml
@@ -38,10 +38,23 @@ parameters:
       repo_server: null
       repo_server_vault_agent: null
       server: null
+
+    # Test operator params
     operator:
       migrate: true
       env:
         FOO: bar
+      controller_cluster_role_selectors:
+        admin:
+          matchLabels:
+            rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        appcontroller:
+          matchLabels:
+            syn.tools/aggregate-to-argocd-application-controller: "true"
+      server_cluster_role_selectors:
+        server:
+          matchLabels:
+            syn.tools/aggregate-to-argocd-server: "true"
 
     instances:
       another-ns/nulled: null


### PR DESCRIPTION
These cluster roles are populated via aggregation (based on user provided label selectors) and configured as `CONTROLLER_CLUSTER_ROLE` and `SERVER_CLUSTER_ROLE` on the operator deployment.

If these roles are deployed, user-provided values for the `CLUSTER_ROLE` operator env vars are ignored.

See https://argocd-operator.readthedocs.io/en/latest/usage/custom_roles/ for upstream documentation.


Follow-up to #230

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
