### PR TITLE
Fix missing parameter name updates in documentation and comments

### DIFF
--- a/component/rbac.jsonnet
+++ b/component/rbac.jsonnet
@@ -59,7 +59,7 @@ local aggregated_rbac = [
 // argocd-operator's `CONTROLLER_CLUSTER_ROLE` and `SERVER_CLUSTER_ROLE`, cf.
 // https://argocd-operator.readthedocs.io/en/latest/usage/custom_roles/
 // NOTE(sg): we only deploy these cluster roles if the respective
-// `cluster_role_match_labels` parameter in `operator` isn't empty.
+// `cluster_role_selectors` parameter in `operator` isn't empty.
 local internalControllerAggregationLabel = {
   'rbac.argocd.syn.tools/aggregate-to-controller': 'true',
 };

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -410,12 +410,12 @@ This variable is configured through component parameter `operator.cluster_scope_
 
 [NOTE]
 ====
-When parameter `operator.controller_cluster_role_match_labels` isn't empty, setting `CONTROLLER_CUSTOM_ROLE` through this parameter has no effect.
+When parameter `operator.controller_cluster_role_selectors` isn't empty, setting `CONTROLLER_CUSTOM_ROLE` through this parameter has no effect.
 ====
 
 [NOTE]
 ====
-When parameter `operator.server_cluster_role_match_labels` isn't empty, setting `SERVER_CUSTOM_ROLE` through this parameter has no effect.
+When parameter `operator.server_cluster_role_selectors` isn't empty, setting `SERVER_CUSTOM_ROLE` through this parameter has no effect.
 ====
 
 [IMPORTANT]


### PR DESCRIPTION
The `operator.*_cluster_role_match_labels` parameter was adjusted to `_cluster_role_selectors` in #231, but we missed some references to the old names.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
