### PR TITLE
Switch from `bitnami/kubectl` to `quay.io/appuio/oc` image

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "98d16f99766e6c6d97322dbe42e058f0e2bf73d0",
+  "commit": "56dd2ee980f197ec2c8b3977c16458e43d0c6ef2",
   "checkout": "main",
   "context": {
     "cookiecutter": {
@@ -17,14 +17,15 @@
       "automerge_patch_v0": "n",
       "automerge_patch_regexp_blocklist": "",
       "automerge_patch_v0_regexp_allowlist": "",
-      "automerge_minor_regexp_allowlist": "",
+      "automerge_minor_regexp_allowlist": "^quay.io/appuio/oc$",
       "auto_release": "y",
       "copyright_holder": "VSHN AG <info@vshn.ch>",
       "copyright_year": "2021",
       "github_owner": "projectsyn",
       "github_name": "component-argocd",
       "github_url": "https://github.com/projectsyn/component-argocd",
-      "_template": "https://github.com/projectsyn/commodore-component-template.git"
+      "_template": "https://github.com/projectsyn/commodore-component-template.git",
+      "_commit": "56dd2ee980f197ec2c8b3977c16458e43d0c6ef2"
     }
   },
   "directory": null

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -32,10 +32,10 @@ parameters:
     http_credentials_secret_name: catalog-http-credentials
 
     images:
-      kubectl:
-        registry: docker.io
-        repository: bitnami/kubectl
-        tag: '1.30.7@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b'
+      oc:
+        registry: quay.io
+        repository: appuio/oc
+        tag: v4.18
       kapitan:
         registry: docker.io
         repository: kapicorp/kapitan

--- a/component/argocd.jsonnet
+++ b/component/argocd.jsonnet
@@ -468,7 +468,7 @@ local tls_cronjob =
             spec+: {
               containers_: {
                 refresh: kube.Container('refresh') {
-                  image: common.render_image('oc'),
+                  image: common.render_image('oc', include_tag=true),
                   command: [
                     'kubectl',
                     'delete',

--- a/component/argocd.jsonnet
+++ b/component/argocd.jsonnet
@@ -468,7 +468,7 @@ local tls_cronjob =
             spec+: {
               containers_: {
                 refresh: kube.Container('refresh') {
-                  image: common.render_image('kubectl'),
+                  image: common.render_image('oc'),
                   command: [
                     'kubectl',
                     'delete',

--- a/component/hooks.jsonnet
+++ b/component/hooks.jsonnet
@@ -60,7 +60,7 @@ local createJob(jobName, hook, args) = kube.Job(jobName) {
         containers_+: {
           annotate_argocd: kube.Container(jobName) {
             workingDir: '/home',
-            image: common.render_image('kubectl', include_tag=true),
+            image: common.render_image('oc', include_tag=true),
             command: [ 'kubectl' ],
             args: args,
             env: [

--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,21 @@
         "automerge",
         "bump:patch"
       ]
+    },
+    {
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "automerge": true,
+      "platformAutomerge": false,
+      "labels": [
+        "dependency",
+        "automerge",
+        "bump:minor"
+      ],
+      "matchPackagePatterns": [
+        "^quay.io/appuio/oc$"
+      ]
     }
   ]
 }

--- a/tests/golden/defaults/argocd/argocd/25_hooks/hooks.yaml
+++ b/tests/golden/defaults/argocd/argocd/25_hooks/hooks.yaml
@@ -83,7 +83,7 @@ spec:
           env:
             - name: HOME
               value: /home
-          image: docker.io/bitnami/kubectl:1.30.7@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b
+          image: quay.io/appuio/oc:v4.18
           imagePullPolicy: IfNotPresent
           name: argocd-post-sync
           ports: []

--- a/tests/golden/defaults/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: docker.io/bitnami/kubectl
+              image: quay.io/appuio/oc
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []

--- a/tests/golden/defaults/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: quay.io/appuio/oc
+              image: quay.io/appuio/oc:v4.18
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []

--- a/tests/golden/https-catalog/argocd/argocd/25_hooks/hooks.yaml
+++ b/tests/golden/https-catalog/argocd/argocd/25_hooks/hooks.yaml
@@ -83,7 +83,7 @@ spec:
           env:
             - name: HOME
               value: /home
-          image: docker.io/bitnami/kubectl:1.30.7@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b
+          image: quay.io/appuio/oc:v4.18
           imagePullPolicy: IfNotPresent
           name: argocd-post-sync
           ports: []

--- a/tests/golden/https-catalog/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/https-catalog/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: docker.io/bitnami/kubectl
+              image: quay.io/appuio/oc
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []

--- a/tests/golden/https-catalog/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/https-catalog/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: quay.io/appuio/oc
+              image: quay.io/appuio/oc:v4.18
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []

--- a/tests/golden/openshift/argocd/argocd/25_hooks/hooks.yaml
+++ b/tests/golden/openshift/argocd/argocd/25_hooks/hooks.yaml
@@ -83,7 +83,7 @@ spec:
           env:
             - name: HOME
               value: /home
-          image: docker.io/bitnami/kubectl:1.30.7@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b
+          image: quay.io/appuio/oc:v4.18
           imagePullPolicy: IfNotPresent
           name: argocd-post-sync
           ports: []

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: docker.io/bitnami/kubectl
+              image: quay.io/appuio/oc
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: quay.io/appuio/oc
+              image: quay.io/appuio/oc:v4.18
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []

--- a/tests/golden/params/argocd/argocd/25_hooks/hooks.yaml
+++ b/tests/golden/params/argocd/argocd/25_hooks/hooks.yaml
@@ -83,7 +83,7 @@ spec:
           env:
             - name: HOME
               value: /home
-          image: docker.io/bitnami/kubectl:1.30.7@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b
+          image: quay.io/appuio/oc:v4.18
           imagePullPolicy: IfNotPresent
           name: argocd-post-sync
           ports: []

--- a/tests/golden/params/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: docker.io/bitnami/kubectl
+              image: quay.io/appuio/oc
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []

--- a/tests/golden/params/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: quay.io/appuio/oc
+              image: quay.io/appuio/oc:v4.18
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []

--- a/tests/golden/prometheus/argocd/argocd/25_hooks/hooks.yaml
+++ b/tests/golden/prometheus/argocd/argocd/25_hooks/hooks.yaml
@@ -83,7 +83,7 @@ spec:
           env:
             - name: HOME
               value: /home
-          image: docker.io/bitnami/kubectl:1.30.7@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b
+          image: quay.io/appuio/oc:v4.18
           imagePullPolicy: IfNotPresent
           name: argocd-post-sync
           ports: []

--- a/tests/golden/prometheus/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/prometheus/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: docker.io/bitnami/kubectl
+              image: quay.io/appuio/oc
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []

--- a/tests/golden/prometheus/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/prometheus/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: quay.io/appuio/oc
+              image: quay.io/appuio/oc:v4.18
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []

--- a/tests/golden/syn-teams/argocd/argocd/25_hooks/hooks.yaml
+++ b/tests/golden/syn-teams/argocd/argocd/25_hooks/hooks.yaml
@@ -83,7 +83,7 @@ spec:
           env:
             - name: HOME
               value: /home
-          image: docker.io/bitnami/kubectl:1.30.7@sha256:1249fc292e84a38575ee0cadc3e28dcd7ddf5a3a4e5da401b1a8599e8ac52a1b
+          image: quay.io/appuio/oc:v4.18
           imagePullPolicy: IfNotPresent
           name: argocd-post-sync
           ports: []

--- a/tests/golden/syn-teams/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/syn-teams/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: docker.io/bitnami/kubectl
+              image: quay.io/appuio/oc
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []

--- a/tests/golden/syn-teams/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
+++ b/tests/golden/syn-teams/argocd/argocd/30_argocd/10_refresh_argocd_tls.yaml
@@ -74,7 +74,7 @@ spec:
               env:
                 - name: HOME
                   value: /home/refresh
-              image: quay.io/appuio/oc
+              image: quay.io/appuio/oc:v4.18
               imagePullPolicy: IfNotPresent
               name: refresh
               ports: []


### PR DESCRIPTION
We introduce a new parameter `images.oc` for the `appuio/oc` image so we can gracefully upgrade the necessary configurations in our global defaults and tenant repos (registry/repository overrides).

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
