### PR TITLE
Set priorityClassName in pods of default ArgoCD

### DIFF
--- a/class/argocd.yml
+++ b/class/argocd.yml
@@ -25,6 +25,7 @@ parameters:
         input_type: jsonnet
         input_paths:
           - argocd/component/argocd.jsonnet
+          - argocd/component/argocd-priority-class.jsonnet
       - output_path: argocd/90_instances/
         input_type: jsonnet
         input_paths:

--- a/component/argocd-priority-class.jsonnet
+++ b/component/argocd-priority-class.jsonnet
@@ -1,0 +1,36 @@
+local esp = import 'lib/espejote.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local inv = kap.inventory();
+
+local params = inv.parameters.argocd;
+
+{
+  '10_argocd_priority_class': esp.admission('argocd-set-priority-class', params.namespace) {
+    spec: {
+      mutating: true,
+      template: importstr 'espejote-templates/argocd-priority-class.jsonnet',
+      webhookConfiguration: {
+        rules: [
+          {
+            apiGroups: [ '' ],
+            apiVersions: [ '*' ],
+            operations: [ 'CREATE' ],
+            resources: [ 'pods' ],
+          },
+        ],
+        objectSelector: {
+          matchExpressions: [ {
+            key: 'app.kubernetes.io/name',
+            operator: 'In',
+            values: [
+              'syn-argocd-server',
+              'syn-argocd-repo-server',
+              'syn-argocd-application-controller',
+              'syn-argocd-redis',
+            ],
+          } ],
+        },
+      },
+    },
+  },
+}

--- a/component/espejote-templates/argocd-priority-class.jsonnet
+++ b/component/espejote-templates/argocd-priority-class.jsonnet
@@ -1,0 +1,26 @@
+local esp = import 'espejote.libsonnet';
+local admission = esp.ALPHA.admission;
+
+local pod = admission.admissionRequest().object;
+local hasPriorityClass = std.get(pod.spec, 'priorityClassName') != null;
+
+local removePriority =
+  admission.jsonPatchOp(
+    'remove',
+    '/spec/priority',
+  );
+
+local addPriorityClass = if hasPriorityClass then
+  admission.jsonPatchOp(
+    'replace',
+    '/spec/priorityClassName',
+    'system-cluster-critical',
+  )
+else
+  admission.jsonPatchOp(
+    'add',
+    '/spec/priorityClassName',
+    'system-cluster-critical',
+  );
+
+admission.patched('added priorityClassName', admission.assertPatch([ removePriority, addPriorityClass ]))

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -4,6 +4,9 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/master/lib/cert-manager.libsonnet
         output_path: vendor/lib/cert-manager.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
 
   secret_management:
     vault_role: test

--- a/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
@@ -1,0 +1,55 @@
+apiVersion: espejote.io/v1alpha1
+kind: Admission
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-set-priority-class
+  name: argocd-set-priority-class
+  namespace: syn
+spec:
+  mutating: true
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local admission = esp.ALPHA.admission;
+
+    local pod = admission.admissionRequest().object;
+    local hasPriorityClass = std.get(pod.spec, 'priorityClassName') != null;
+
+    local removePriority =
+      admission.jsonPatchOp(
+        'remove',
+        '/spec/priority',
+      );
+
+    local addPriorityClass = if hasPriorityClass then
+      admission.jsonPatchOp(
+        'replace',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      )
+    else
+      admission.jsonPatchOp(
+        'add',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      );
+
+    admission.patched('added priorityClassName', admission.assertPatch([ removePriority, addPriorityClass ]))
+  webhookConfiguration:
+    objectSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - syn-argocd-server
+            - syn-argocd-repo-server
+            - syn-argocd-application-controller
+            - syn-argocd-redis
+    rules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+        resources:
+          - pods

--- a/tests/golden/https-catalog/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
+++ b/tests/golden/https-catalog/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
@@ -1,0 +1,55 @@
+apiVersion: espejote.io/v1alpha1
+kind: Admission
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-set-priority-class
+  name: argocd-set-priority-class
+  namespace: syn
+spec:
+  mutating: true
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local admission = esp.ALPHA.admission;
+
+    local pod = admission.admissionRequest().object;
+    local hasPriorityClass = std.get(pod.spec, 'priorityClassName') != null;
+
+    local removePriority =
+      admission.jsonPatchOp(
+        'remove',
+        '/spec/priority',
+      );
+
+    local addPriorityClass = if hasPriorityClass then
+      admission.jsonPatchOp(
+        'replace',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      )
+    else
+      admission.jsonPatchOp(
+        'add',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      );
+
+    admission.patched('added priorityClassName', admission.assertPatch([ removePriority, addPriorityClass ]))
+  webhookConfiguration:
+    objectSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - syn-argocd-server
+            - syn-argocd-repo-server
+            - syn-argocd-application-controller
+            - syn-argocd-redis
+    rules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+        resources:
+          - pods

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
@@ -1,0 +1,55 @@
+apiVersion: espejote.io/v1alpha1
+kind: Admission
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-set-priority-class
+  name: argocd-set-priority-class
+  namespace: syn
+spec:
+  mutating: true
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local admission = esp.ALPHA.admission;
+
+    local pod = admission.admissionRequest().object;
+    local hasPriorityClass = std.get(pod.spec, 'priorityClassName') != null;
+
+    local removePriority =
+      admission.jsonPatchOp(
+        'remove',
+        '/spec/priority',
+      );
+
+    local addPriorityClass = if hasPriorityClass then
+      admission.jsonPatchOp(
+        'replace',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      )
+    else
+      admission.jsonPatchOp(
+        'add',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      );
+
+    admission.patched('added priorityClassName', admission.assertPatch([ removePriority, addPriorityClass ]))
+  webhookConfiguration:
+    objectSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - syn-argocd-server
+            - syn-argocd-repo-server
+            - syn-argocd-application-controller
+            - syn-argocd-redis
+    rules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+        resources:
+          - pods

--- a/tests/golden/params/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
@@ -1,0 +1,55 @@
+apiVersion: espejote.io/v1alpha1
+kind: Admission
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-set-priority-class
+  name: argocd-set-priority-class
+  namespace: syn
+spec:
+  mutating: true
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local admission = esp.ALPHA.admission;
+
+    local pod = admission.admissionRequest().object;
+    local hasPriorityClass = std.get(pod.spec, 'priorityClassName') != null;
+
+    local removePriority =
+      admission.jsonPatchOp(
+        'remove',
+        '/spec/priority',
+      );
+
+    local addPriorityClass = if hasPriorityClass then
+      admission.jsonPatchOp(
+        'replace',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      )
+    else
+      admission.jsonPatchOp(
+        'add',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      );
+
+    admission.patched('added priorityClassName', admission.assertPatch([ removePriority, addPriorityClass ]))
+  webhookConfiguration:
+    objectSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - syn-argocd-server
+            - syn-argocd-repo-server
+            - syn-argocd-application-controller
+            - syn-argocd-redis
+    rules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+        resources:
+          - pods

--- a/tests/golden/prometheus/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
+++ b/tests/golden/prometheus/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
@@ -1,0 +1,55 @@
+apiVersion: espejote.io/v1alpha1
+kind: Admission
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-set-priority-class
+  name: argocd-set-priority-class
+  namespace: syn
+spec:
+  mutating: true
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local admission = esp.ALPHA.admission;
+
+    local pod = admission.admissionRequest().object;
+    local hasPriorityClass = std.get(pod.spec, 'priorityClassName') != null;
+
+    local removePriority =
+      admission.jsonPatchOp(
+        'remove',
+        '/spec/priority',
+      );
+
+    local addPriorityClass = if hasPriorityClass then
+      admission.jsonPatchOp(
+        'replace',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      )
+    else
+      admission.jsonPatchOp(
+        'add',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      );
+
+    admission.patched('added priorityClassName', admission.assertPatch([ removePriority, addPriorityClass ]))
+  webhookConfiguration:
+    objectSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - syn-argocd-server
+            - syn-argocd-repo-server
+            - syn-argocd-application-controller
+            - syn-argocd-redis
+    rules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+        resources:
+          - pods

--- a/tests/golden/syn-teams/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
+++ b/tests/golden/syn-teams/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
@@ -1,0 +1,55 @@
+apiVersion: espejote.io/v1alpha1
+kind: Admission
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-set-priority-class
+  name: argocd-set-priority-class
+  namespace: syn
+spec:
+  mutating: true
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local admission = esp.ALPHA.admission;
+
+    local pod = admission.admissionRequest().object;
+    local hasPriorityClass = std.get(pod.spec, 'priorityClassName') != null;
+
+    local removePriority =
+      admission.jsonPatchOp(
+        'remove',
+        '/spec/priority',
+      );
+
+    local addPriorityClass = if hasPriorityClass then
+      admission.jsonPatchOp(
+        'replace',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      )
+    else
+      admission.jsonPatchOp(
+        'add',
+        '/spec/priorityClassName',
+        'system-cluster-critical',
+      );
+
+    admission.patched('added priorityClassName', admission.assertPatch([ removePriority, addPriorityClass ]))
+  webhookConfiguration:
+    objectSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - syn-argocd-server
+            - syn-argocd-repo-server
+            - syn-argocd-application-controller
+            - syn-argocd-redis
+    rules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+        resources:
+          - pods

--- a/tests/https-catalog.yml
+++ b/tests/https-catalog.yml
@@ -1,4 +1,10 @@
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
+
   cluster:
     catalog_url: https://git.example.com/cluster-catalog.git
 

--- a/tests/openshift.yml
+++ b/tests/openshift.yml
@@ -12,6 +12,9 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/master/lib/cert-manager.libsonnet
         output_path: vendor/lib/cert-manager.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
 
   patch_operator:
     namespace: syn-patch-operator

--- a/tests/params.yml
+++ b/tests/params.yml
@@ -5,6 +5,9 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/master/lib/cert-manager.libsonnet
         output_path: vendor/lib/cert-manager.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
 
   secret_management:
     vault_role: test

--- a/tests/prometheus.yml
+++ b/tests/prometheus.yml
@@ -16,6 +16,9 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/master/lib/cert-manager.libsonnet
         output_path: vendor/lib/cert-manager.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
 
   patch_operator:
     namespace: syn-patch-operator

--- a/tests/syn-teams.yml
+++ b/tests/syn-teams.yml
@@ -8,6 +8,9 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/master/lib/cert-manager.libsonnet
         output_path: vendor/lib/cert-manager.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
 
   secret_management:
     vault_role: test


### PR DESCRIPTION
Creates an Espejote Admission to patch the priorityClassName for default ArgoCD instance pods.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
