### PR TITLE
Explicitly configure the Project Syn ArgoCD instance to use `resourceTrackingMethod=label`

### DIFF
--- a/component/argocd.jsonnet
+++ b/component/argocd.jsonnet
@@ -229,6 +229,7 @@ local argocd(name) =
     spec: {
       image: common.render_image('argocd'),
       version: params.images.argocd.tag,
+      resourceTrackingMethod: 'label',
       applicationInstanceLabelKey: 'argocd.argoproj.io/instance',
       controller: applicationController,
       initialSSHKnownHosts: {

--- a/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/defaults/argocd/argocd/30_argocd/10_argocd.yaml
@@ -262,6 +262,7 @@ spec:
             - /spec/scope
         group: apiextensions.k8s.io
         kind: CustomResourceDefinition
+  resourceTrackingMethod: label
   server:
     insecure: true
     logFormat: text

--- a/tests/golden/https-catalog/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/https-catalog/argocd/argocd/30_argocd/10_argocd.yaml
@@ -262,6 +262,7 @@ spec:
             - /spec/scope
         group: apiextensions.k8s.io
         kind: CustomResourceDefinition
+  resourceTrackingMethod: label
   server:
     insecure: true
     logFormat: text

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd.yaml
@@ -265,6 +265,7 @@ spec:
             - /spec/scope
         group: apiextensions.k8s.io
         kind: CustomResourceDefinition
+  resourceTrackingMethod: label
   server:
     host: syn-argocd.example.com
     ingress:

--- a/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/params/argocd/argocd/30_argocd/10_argocd.yaml
@@ -247,6 +247,7 @@ spec:
             - /spec/scope
         group: apiextensions.k8s.io
         kind: CustomResourceDefinition
+  resourceTrackingMethod: label
   server:
     insecure: true
     logFormat: text

--- a/tests/golden/prometheus/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/prometheus/argocd/argocd/30_argocd/10_argocd.yaml
@@ -262,6 +262,7 @@ spec:
             - /spec/scope
         group: apiextensions.k8s.io
         kind: CustomResourceDefinition
+  resourceTrackingMethod: label
   server:
     insecure: true
     logFormat: text

--- a/tests/golden/syn-teams/argocd/argocd/30_argocd/10_argocd.yaml
+++ b/tests/golden/syn-teams/argocd/argocd/30_argocd/10_argocd.yaml
@@ -262,6 +262,7 @@ spec:
             - /spec/scope
         group: apiextensions.k8s.io
         kind: CustomResourceDefinition
+  resourceTrackingMethod: label
   server:
     insecure: true
     logFormat: text


### PR DESCRIPTION
With operator v0.17 the default for resourceTrackingMethod is annotation. This caused ArgoCD to adopt foreign resources.
This PR hardcodes resourceTrackingMethod to label.

## Additional context

We should have already explicitly configured `resourceTrackingMethod` when we upgraded to ArgoCD v3, but we decided not to, since the operator was still defaulting to `label`. However, with the upgrade to operator v0.17.0 (#266), the default has switched to `annotation`. To ensure we don't cause chaos by randomly stepping on other instances' tracking annotations we explicitly configure the Project Syn instance to use `resourceTrackignMethod=label`.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
