### PR TITLE
Fix ArgoCD bootstrap blocked by missing espejote CRDs

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -61,6 +61,7 @@ local app = argocd.App('argocd', params.namespace, secrets=false) {
     syncPolicy+: {
       syncOptions+: [
         'ServerSideApply=true',
+        'SkipDryRunOnMissingResource=true',
       ],
       automated+: {
         [if params.operator.migrate then 'prune' else null]: false,

--- a/component/argocd-priority-class.jsonnet
+++ b/component/argocd-priority-class.jsonnet
@@ -10,6 +10,13 @@ local hasEspejote = std.member(inv.applications, 'espejote');
 if hasEspejote then
   {
     '10_argocd_priority_class': esp.admission('argocd-set-priority-class', params.namespace) {
+      metadata+: {
+        annotations: {
+          // We set a higher sync-wave than the syn ArgoCD instance to ensure
+          // bootstrap is not blocked my missing espejote CRDs
+          'argocd.argoproj.io/sync-wave': '20',
+        },
+      },
       spec: {
         mutating: true,
         template: importstr 'espejote-templates/argocd-priority-class.jsonnet',

--- a/tests/golden/defaults/argocd/apps/10_argocd.yaml
+++ b/tests/golden/defaults/argocd/apps/10_argocd.yaml
@@ -22,3 +22,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
+      - SkipDryRunOnMissingResource=true

--- a/tests/golden/https-catalog/argocd/apps/10_argocd.yaml
+++ b/tests/golden/https-catalog/argocd/apps/10_argocd.yaml
@@ -22,3 +22,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
+      - SkipDryRunOnMissingResource=true

--- a/tests/golden/openshift/argocd/apps/10_argocd.yaml
+++ b/tests/golden/openshift/argocd/apps/10_argocd.yaml
@@ -22,3 +22,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
+      - SkipDryRunOnMissingResource=true

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
@@ -1,6 +1,8 @@
 apiVersion: espejote.io/v1alpha1
 kind: Admission
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: argocd-set-priority-class
   name: argocd-set-priority-class

--- a/tests/golden/params/argocd/apps/10_argocd.yaml
+++ b/tests/golden/params/argocd/apps/10_argocd.yaml
@@ -22,3 +22,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
+      - SkipDryRunOnMissingResource=true

--- a/tests/golden/prometheus/argocd/apps/10_argocd.yaml
+++ b/tests/golden/prometheus/argocd/apps/10_argocd.yaml
@@ -22,3 +22,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
+      - SkipDryRunOnMissingResource=true

--- a/tests/golden/syn-teams/argocd/apps/10_argocd.yaml
+++ b/tests/golden/syn-teams/argocd/apps/10_argocd.yaml
@@ -22,3 +22,4 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
+      - SkipDryRunOnMissingResource=true


### PR DESCRIPTION
During the setup of a fresh OpenShift 4.21 cluster we discovered that the new espejote admission to set the priority class blocks the ArgoCD bootstrap, because the espejote CRDs are not yet available.

This PR sets the `SkipDryRunOnMissingResource=true` sync option for the whole argocd application to prevent sync errors, also for similar cases in the future. We also add a higher sync wave for the espejote admission to ensure that the syn argocd instance is created first.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
