### PR TITLE
Set `syncPolicy.automated.enabled=true` on ArgoCD apps by default

### DIFF
--- a/lib/argocd.libjsonnet
+++ b/lib/argocd.libjsonnet
@@ -66,6 +66,7 @@ local ArgoApp(component, namespace, project=null, secrets=true, base=null) =
       },
       syncPolicy: {
         automated: {
+          enabled: true,
           prune: true,
           selfHeal: true,
         },

--- a/tests/golden/defaults/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/defaults/argocd/apps/01_rootapp.yaml
@@ -16,6 +16,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: false
       selfHeal: true
     syncOptions:

--- a/tests/golden/defaults/argocd/apps/10_argocd.yaml
+++ b/tests/golden/defaults/argocd/apps/10_argocd.yaml
@@ -18,6 +18,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: true
       selfHeal: true
     syncOptions:

--- a/tests/golden/https-catalog/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/https-catalog/argocd/apps/01_rootapp.yaml
@@ -16,6 +16,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: false
       selfHeal: true
     syncOptions:

--- a/tests/golden/https-catalog/argocd/apps/10_argocd.yaml
+++ b/tests/golden/https-catalog/argocd/apps/10_argocd.yaml
@@ -18,6 +18,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: true
       selfHeal: true
     syncOptions:

--- a/tests/golden/openshift/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/openshift/argocd/apps/01_rootapp.yaml
@@ -16,6 +16,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: false
       selfHeal: true
     syncOptions:

--- a/tests/golden/openshift/argocd/apps/10_argocd.yaml
+++ b/tests/golden/openshift/argocd/apps/10_argocd.yaml
@@ -18,6 +18,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: true
       selfHeal: true
     syncOptions:

--- a/tests/golden/params/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/params/argocd/apps/01_rootapp.yaml
@@ -16,6 +16,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: false
       selfHeal: true
     syncOptions:

--- a/tests/golden/params/argocd/apps/10_argocd.yaml
+++ b/tests/golden/params/argocd/apps/10_argocd.yaml
@@ -18,6 +18,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: false
       selfHeal: true
     syncOptions:

--- a/tests/golden/prometheus/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/prometheus/argocd/apps/01_rootapp.yaml
@@ -16,6 +16,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: false
       selfHeal: true
     syncOptions:

--- a/tests/golden/prometheus/argocd/apps/10_argocd.yaml
+++ b/tests/golden/prometheus/argocd/apps/10_argocd.yaml
@@ -18,6 +18,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: true
       selfHeal: true
     syncOptions:

--- a/tests/golden/syn-teams/argocd/apps-fragrant-flower/01_rootapp.yaml
+++ b/tests/golden/syn-teams/argocd/apps-fragrant-flower/01_rootapp.yaml
@@ -16,6 +16,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: false
       selfHeal: true
     syncOptions:

--- a/tests/golden/syn-teams/argocd/apps/01_rootapp.yaml
+++ b/tests/golden/syn-teams/argocd/apps/01_rootapp.yaml
@@ -16,6 +16,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: false
       selfHeal: true
     syncOptions:

--- a/tests/golden/syn-teams/argocd/apps/10_argocd.yaml
+++ b/tests/golden/syn-teams/argocd/apps/10_argocd.yaml
@@ -18,6 +18,7 @@ spec:
     targetRevision: HEAD
   syncPolicy:
     automated:
+      enabled: true
       prune: true
       selfHeal: true
     syncOptions:


### PR DESCRIPTION
Recent ArgoCD versions set `syncPolicy.automated.enabled=false` when users disable auto-sync through the UI. Because this field wasn't managed through our GitOps repo, it stayed `false` even when the user then tried to re-enable auto-sync by syncing the root app manually.

This commit sets the field to `true` in the GitOps repo, which should restore the desired behavior of the root apps ensuring that auto-sync is on unless a user explicitly disables auto-sync on the root app and a managed app.

See also https://argo-cd.readthedocs.io/en/latest/user-guide/auto_sync/#automated-sync-policy




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
