### PR TITLE
Drop empty objects in ArgoCD instance networkpolicy rendering

### DIFF
--- a/component/argocd.jsonnet
+++ b/component/argocd.jsonnet
@@ -537,7 +537,12 @@ local tls_refresh = [
   '00_ssh_secret': ssh_secret,
   '00_repo_secret': repo_secret,
   '10_argocd': argocd('syn-argocd'),
-  [if params.network_policies.enabled then '20_networkpolicy']: std.map(function(p) com.namespaced(params.namespace, p), import 'networkpolicy.libsonnet'),
+  [if params.network_policies.enabled then '20_networkpolicy']:
+    std.filterMap(
+      function(it) std.length(it) > 0,
+      function(p) com.namespaced(params.namespace, p),
+      import 'networkpolicy.libsonnet'
+    ),
   // Manually adding certificate for conversion webhook
   // as the upstream kustomize is broken.
   // 2023/02/19 sfe


### PR DESCRIPTION
When component-prometheus is present on a cluster but no default instance is configured, the `prometheus.libsonnet` helper function `NetworkPolicy` returns an empty object.

Without this commit, component-argocd injects `metadata.namespace` in that object and adds it to the cluster catalog. This causes an error in ArgoCD which can't deserialize manifests that don't have field `kind`.

This commit drops empty networkpolicy objects before the namespace is injected.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
