### PR TITLE
Apply `monitoring.coreos.com/v1` resources after ArgoCD custom resource

### DIFF
--- a/component/monitoring.libsonnet
+++ b/component/monitoring.libsonnet
@@ -11,6 +11,13 @@ local serviceMonitor(objname, name) =
     metadata: {
       name: objname,
       namespace: params.namespace,
+      annotations: {
+        // NOTE(sg): moving servicemonitor sync after argocd custom resource,
+        // same as espejote admission. This should ensure that bootstrap works
+        // on clusters where the ServiceMonitor CRD is installed via
+        // component-prometheus.
+        'argocd.argoproj.io/sync-wave': '20',
+      },
       labels: {
         name: objname,
         'app.kubernetes.io/name': name,
@@ -41,6 +48,13 @@ local alert_rules =
     metadata: {
       name: 'argocd',
       namespace: params.namespace,
+      annotations: {
+        // NOTE(sg): moving servicemonitor sync after argocd custom resource,
+        // same as espejote admission. This should ensure that bootstrap works
+        // on clusters where the ServiceMonitor CRD is installed via
+        // component-prometheus.
+        'argocd.argoproj.io/sync-wave': '20',
+      },
       labels: {
         name: 'argocd',
         role: 'alert-rules',

--- a/tests/golden/defaults/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/defaults/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
@@ -18,6 +20,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
@@ -35,6 +39,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
@@ -52,6 +58,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     cluster_id: c-green-test-1234
     name: argocd

--- a/tests/golden/https-catalog/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/https-catalog/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
@@ -18,6 +20,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
@@ -35,6 +39,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
@@ -52,6 +58,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     cluster_id: c-green-test-1234
     name: argocd

--- a/tests/golden/openshift/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/openshift/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
@@ -18,6 +20,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
@@ -35,6 +39,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
@@ -52,6 +58,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     cluster_id: c-green-test-1234
     name: argocd

--- a/tests/golden/params/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/params/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
@@ -18,6 +20,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
@@ -35,6 +39,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
@@ -52,6 +58,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     cluster_id: c-green-test-1234
     name: argocd

--- a/tests/golden/prometheus/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/prometheus/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
@@ -19,6 +21,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
@@ -37,6 +41,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
@@ -55,6 +61,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     cluster_id: c-green-test-1234
     monitoring.syn.tools/enabled: 'true'

--- a/tests/golden/syn-teams/argocd/argocd/01_namespace/20_monitoring.yaml
+++ b/tests/golden/syn-teams/argocd/argocd/01_namespace/20_monitoring.yaml
@@ -1,6 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-metrics
     app.kubernetes.io/part-of: argocd
@@ -18,6 +20,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-server-metrics
     app.kubernetes.io/part-of: argocd
@@ -35,6 +39,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     app.kubernetes.io/name: syn-argocd-repo-server
     app.kubernetes.io/part-of: argocd
@@ -52,6 +58,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
   labels:
     cluster_id: c-green-test-1234
     name: argocd


### PR DESCRIPTION
This should fix bootstrap on clusters where the `monitoring.coreos.com/v1` custom resources are deployed by component-prometheus.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
