### PR TITLE
Configure argocd-priority-class webhook with `failurePolicy=Ignore`

### DIFF
--- a/component/argocd-priority-class.jsonnet
+++ b/component/argocd-priority-class.jsonnet
@@ -21,6 +21,9 @@ if hasEspejote then
         mutating: true,
         template: importstr 'espejote-templates/argocd-priority-class.jsonnet',
         webhookConfiguration: {
+          // NOTE(sg): We want ArgoCD pods to be admitted without the mutation
+          // if Espejote is unavailable for any reason.
+          failurePolicy: 'Ignore',
           rules: [
             {
               apiGroups: [ '' ],

--- a/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
+++ b/tests/golden/openshift/argocd/argocd/30_argocd/10_argocd_priority_class.yaml
@@ -37,6 +37,7 @@ spec:
 
     admission.patched('added priorityClassName', admission.assertPatch([ removePriority, addPriorityClass ]))
   webhookConfiguration:
+    failurePolicy: Ignore
     objectSelector:
       matchExpressions:
         - key: app.kubernetes.io/name


### PR DESCRIPTION
We've noticed that on smaller clusters (e.g. 1 worker, 1 control plane), there's a significant chance that some ArgoCD pods aren't recreated when Espejote and ArgoCD pods get evicted in parallel.

Changing the mutating admission webhook to `failurePolicy=Ignore` should ensure that ArgoCD pods always start (albeit sometimes without the desired priority class). Notably, this case should be rare on more robust environments (HA control plane, or multiple workers), where we actually care that the Syn ArgoCD has `system-cluster-critical` priority class.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
